### PR TITLE
add llm-based execution plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ logs/
 *.sqlite3
 .claude/
 .codex
+.vscode
 
 #runtime generated
 .jobs/

--- a/agentic/controller.py
+++ b/agentic/controller.py
@@ -65,6 +65,14 @@ class RunCoordinator:
         job_id: str | None = None,
         event_handler: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
+        # Run-mode clarification is temporarily disabled.
+        return {
+            "status": "not_requested",
+            "clarification_turns": 0,
+            "clarification_transcript": [],
+            "resolved_task": task,
+            "resolved_slots": {},
+        }
         if self.llm_provider is None or not ask_user:
             return {
                 "status": "not_requested",

--- a/docs/tools/security_audit_en.md
+++ b/docs/tools/security_audit_en.md
@@ -171,7 +171,6 @@ metadata:
           source_stage_id: str | null # Real upstream stage id when routing from prior results, e.g. stage_2; null for single stage
           rules: list[str]     # Review rules for uncertain mode, e.g. near_threshold / low_confidence / conflicting / error / content_filter / unflagged
           dataset_types: list[str] # Optional dataset-type routing, e.g. dpo / sft / rl / benchmark
-          required_fields: list[str] # Optional routing by real DataSample fields, e.g. response / context / chosen_response / rejected_response
           sample_rate: float   # Optional sampling ratio for sample mode, from 0.0 to 1.0
           sample_size: int     # Optional maximum sample count for sample mode
           threshold: float     # Optional decision threshold used by near_threshold, usually 0.5 by default

--- a/docs/tools/security_audit_en.md
+++ b/docs/tools/security_audit_en.md
@@ -69,8 +69,29 @@ Example input sample:
 | `data` | `list[dict]` | Yes | — | List of dataset records to audit |
 | `checker_selection_mode` | `str` | No | `default` | Checker selection intent: `explicit`, `recommend`, or `default` |
 | `checker_names` | `list[str]` | No | `[]` | Checker class names for `explicit` mode. If provided without `checker_selection_mode`, the request is treated as `explicit`; see [Checkers](#checkers) |
-| `checker_preferences` | `str` | No | `""` | Natural-language preferences for `recommend` mode, such as low cost, fast, high accuracy, or stronger coverage |
+| `audit_intent` | `str` | No | `""` | Natural-language audit intent for `recommend` mode, including target risks, audit scope, and constraints such as low cost, speed, high accuracy, or stronger coverage |
 | `max_workers` | `int` | No | `4` | Number of parallel worker threads |
+
+
+## Resolver
+
+The resolver turns the checker-selection intent passed by the agent into an executable audit plan. Its responsibilities include selecting checkers within the current `capability_set`, organizing audit stages, designing sample routing, and recording deterministic degradations when a target cannot be fully satisfied.
+
+The tool currently supports three resolution paths:
+
+- `explicit`: when the user provides `checker_names`, the tool deterministically enables those checkers and filters out entries disallowed by the current runtime policy.
+- `default`: when no recommendation intent is provided, the tool resolves checkers from the configured default set.
+- `recommend`: when the user asks the tool to select and orchestrate checkers from a natural-language audit intent, the request enters the LLM resolver. The LLM resolver uses `audit_intent`, runtime policy, and the capability set to generate a plan. If the LLM is unavailable or returns an invalid plan, the tool falls back to a deterministic plan and records the reason in `degradations`.
+
+The LLM resolver uses a baseline Progressive Risk Audit Workflow as its default plan template. `review` is not a mandatory stage; it is conditionally triggered by upstream results.
+
+| Stage | Goal | Typical checkers / capabilities | Routing intent |
+|-------|------|----------------------------------|----------------|
+| `quick_scan` | Run low-cost full-scan checks first to catch PII, secrets, obvious harmful/toxic/bias signals, and other surface risks | `PIIRule`, `SecretRule`, keyword rules, `PIILLMJudge`, `PIINERDetector` | Usually all samples |
+| `semantic_scan` | Judge semantic risks such as harmful content, toxicity, bias, jailbreaks, prompt injection, label flipping, factual inconsistency, and instruction mismatch | LLM judge checkers | All samples, sampled data, or field-applicable routed samples |
+| `deep_scan` | Run higher-cost specialist scans when resources allow, covering risks that benefit from dedicated models such as backdoors, jailbreaks, prompt injection, harmful content, and toxicity | `GraCeFulBackdoorDefender`, `HarmfulContentClassifier`, `ToxicityClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`, etc. | Sampled data, high-risk partitions, upstream flagged samples, or user-specified scopes |
+
+This workflow is a default template, not a fixed rule. For partial-risk requests, the LLM may remove irrelevant stages or checkers. For low-cost previews, fast audits, or very large datasets, it may adjust routing, such as sampling, deep-scanning only high-risk samples, or prioritizing specific fields.
 
 
 
@@ -89,7 +110,7 @@ result:
       total: int               # Total samples inspected for this risk
       flagged: int             # Number of hits
     harmful: {total: int, flagged: int}
-    # ... other risk types (14 in total)
+    # ... other risk types (13 in total)
   checker_stats:               # Execution statistics per checker
     PIIRule:
       total: int               # Successfully executed count
@@ -101,35 +122,35 @@ metadata:
   task_name: str               # Audit task name
   checker_names: list[str]     # Checkers used in this run
   runtime_policy:              # Deployment runtime policy used for this run
-    network_mode: str          # Network mode: online / offline
-    resource_tier: str         # Resource tier: light / standard / full
+    network_mode: online | offline # Network mode
+    resource_tier: light | standard | full # Resource tier
   request:                     # Normalized checker selection request
-    checker_selection_mode: str # Checker selection mode: explicit / recommend / default
+    checker_selection_mode: explicit | recommend | default # Checker selection mode
     checker_names: list[str]   # User-specified checkers; usually empty outside explicit mode
-    checker_preferences: str   # Natural-language preferences for recommend mode
+    audit_intent: str          # Natural-language audit intent for recommend mode
   capability_set:              # Checker availability boundary for this run
     allowed_checker_names: list[str]  # Checker names allowed by runtime policy
     blocked_checkers:          # Checkers blocked by policy and their reasons
       - name: str              # Blocked checker name
         reasons: list[str]     # Block reason codes
   resolved_plan:               # Final resolved execution plan
-    schema_version: security_audit.resolved_plan.v1  # Execution plan schema version
-    strategy: deterministic | llm  # Plan resolution strategy; current implementation uses deterministic rules
+    schema_version: security_audit.resolved_plan.v1 # Execution plan schema version
+    strategy: deterministic | llm  # Plan resolution strategy; recommend mode may produce an LLM-resolved multi-stage plan
     source: explicit | default | recommend | fallback  # Plan source
-    stages:                    # Execution stages; current version runs one stage
-      - id: stage_1            # Unique stage id
-        name: single_stage     # Stage name
-        type: single_stage     # Stage type
+    objective: dict            # Audit goal, covered risks, and optimization intent resolved from the plan
+    stages:                    # Execution stages; LLM plans may contain multiple routed stages
+      - id: str                # Unique stage id, e.g. stage_1
+        name: str              # Stage name, e.g. single_stage / quick_scan
+        type: str              # Stage type, e.g. single_stage / semantic_scan
         checkers: list[str]    # Checkers executed in this stage
-        input_scope:           # Input sample scope for this stage
-          type: all_samples    # Scope type; all_samples means all input samples
-          source_stage_id: null # Upstream stage id for multi-stage plans; null for single stage
-        routing:               # Stage routing policy
-          mode: all            # all means run on every sample in the input scope
-    skipped_checkers: list     # Checkers skipped during plan resolution and their reasons
-    degradations: list         # Degradation records from recommendation or planning
+        routing:               # Stage routing policy and the single source of truth for sample selection
+          mode: all_samples | field_applicable | uncertain | sample | high_risk_partition # Routing mode
+          source_stage_id: str | null # Real upstream stage id when routing from prior results, e.g. stage_2; null for single stage
+    skipped_checkers: list[dict] # Checkers skipped during plan resolution and their reasons
+    degradations: list[dict]   # Degradation records from recommendation or planning
   execution:                   # Actual execution parameters
     max_workers: int           # Number of parallel workers
+    stages: list[dict]         # Multi-stage execution stats, including per-stage input count, checkers, and skip reasons
   create_time: str             # Task start time (ISO format)
   finish_time: str             # Task finish time (ISO format)
   checker_stats:               # Execution statistics per checker

--- a/docs/tools/security_audit_en.md
+++ b/docs/tools/security_audit_en.md
@@ -94,6 +94,29 @@ The LLM resolver uses a baseline Progressive Risk Audit Workflow as its default 
 This workflow is a default template, not a fixed rule. For partial-risk requests, the LLM may remove irrelevant stages or checkers. For low-cost previews, fast audits, or very large datasets, it may adjust routing, such as sampling, deep-scanning only high-risk samples, or prioritizing specific fields.
 
 
+### Routing Modes
+
+`routing` decides which samples each stage actually processes. Its main value is changing the audit from "run every checker over every sample" into "route samples dynamically by risk, field availability, cost, and upstream results", improving coverage, recall, and decision reliability under a controlled budget.
+
+| Mode | Description | Typical Use Case |
+|------|-------------|------------------|
+| `all_samples` | Run the stage checkers over all samples. | Low-cost rule-based prescreening, or semantic audits that must cover every sample. |
+| `field_applicable` | Only process samples whose fields or dataset type satisfy the checker requirements. | DPO label flipping only runs on `chosen_response` / `rejected_response`; factual consistency only runs when `context` is present; instruction mismatch / sycophancy / self contradiction only run when `response` is present. |
+| `sample` | Run on a sampled subset of applicable samples, controlled by `sample_rate` or `sample_size`. | Low-cost previews, fast risk estimation on very large datasets, or cost control for expensive checkers. |
+| `uncertain` | Route samples from an upstream stage for second-pass review when they match specific rules. | High-recall second scans, boundary-case review, stricter checks for low-confidence results, and compensation for execution errors or content filtering. |
+
+Common `rules` for `uncertain` routing:
+
+| Rule | Description |
+|------|-------------|
+| `near_threshold` | Review samples whose score is close to the decision threshold, avoiding missed or over-blocked borderline risks. |
+| `low_confidence` | Review samples where the checker confidence is low, using a stronger judgment to compensate for uncertainty. |
+| `conflicting` | Review samples where multiple checkers disagree, acting as an arbitration step to improve final reliability. |
+| `error` | Review samples where the upstream checker failed, avoiding false safety caused by tool errors. |
+| `content_filter` | Review samples that triggered content filtering, avoiding missing conclusions when an LLM refuses or filters high-risk content. |
+| `unflagged` | Review samples not flagged by the upstream stage, useful for high-recall second-pass scans that try to recover false negatives. |
+
+
 
 ## Output
 
@@ -144,8 +167,15 @@ metadata:
         type: str              # Stage type, e.g. single_stage / semantic_scan
         checkers: list[str]    # Checkers executed in this stage
         routing:               # Stage routing policy and the single source of truth for sample selection
-          mode: all_samples | field_applicable | uncertain | sample | high_risk_partition # Routing mode
+          mode: all_samples | field_applicable | uncertain | sample # Routing mode
           source_stage_id: str | null # Real upstream stage id when routing from prior results, e.g. stage_2; null for single stage
+          rules: list[str]     # Review rules for uncertain mode, e.g. near_threshold / low_confidence / conflicting / error / content_filter / unflagged
+          dataset_types: list[str] # Optional dataset-type routing, e.g. dpo / sft / rl / benchmark
+          required_fields: list[str] # Optional routing by real DataSample fields, e.g. response / context / chosen_response / rejected_response
+          sample_rate: float   # Optional sampling ratio for sample mode, from 0.0 to 1.0
+          sample_size: int     # Optional maximum sample count for sample mode
+          threshold: float     # Optional decision threshold used by near_threshold, usually 0.5 by default
+          threshold_margin: float # Optional threshold neighborhood for near_threshold, e.g. 0.1
     skipped_checkers: list[dict] # Checkers skipped during plan resolution and their reasons
     degradations: list[dict]   # Degradation records from recommendation or planning
   execution:                   # Actual execution parameters

--- a/docs/tools/security_audit_en.md
+++ b/docs/tools/security_audit_en.md
@@ -67,7 +67,9 @@ Example input sample:
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `data` | `list[dict]` | Yes | — | List of dataset records to audit |
-| `checker_names` | `list[str]` | No | `[]` | List of Checker class names to enable; see [Checkers](#checkers) |
+| `checker_selection_mode` | `str` | No | `default` | Checker selection intent: `explicit`, `recommend`, or `default` |
+| `checker_names` | `list[str]` | No | `[]` | Checker class names for `explicit` mode. If provided without `checker_selection_mode`, the request is treated as `explicit`; see [Checkers](#checkers) |
+| `checker_preferences` | `str` | No | `""` | Natural-language preferences for `recommend` mode, such as low cost, fast, high accuracy, or stronger coverage |
 | `max_workers` | `int` | No | `4` | Number of parallel worker threads |
 
 
@@ -77,24 +79,59 @@ Example input sample:
 ```yaml
 result:
   security_score: float        # Weighted security score (0.0–1.0; higher is safer)
-  passed: bool                 # true when security_score >= threshold
   total_issues: int            # Number of samples flagged as risky
   flagged_samples: int         # Same as total_issues
   safe_samples: int            # Number of samples not flagged
   total_samples: int           # Total number of samples
   flagged_rate: float          # Flag rate (flagged_samples / total_samples)
-
-metadata:
-  task_name: str               # Audit task name
-  checker_names: list[str]     # Checkers used in this run
-  create_time: str             # Task start time (ISO format)
-  finish_time: str             # Task finish time (ISO format)
   risk_distribution:           # Distribution statistics per risk type
     pii:
       total: int               # Total samples inspected for this risk
       flagged: int             # Number of hits
     harmful: {total: int, flagged: int}
     # ... other risk types (14 in total)
+  checker_stats:               # Execution statistics per checker
+    PIIRule:
+      total: int               # Successfully executed count
+      flagged: int             # Flagged count
+      error: int               # Execution error count
+      content_filter: int      # Content filter triggered count
+
+metadata:
+  task_name: str               # Audit task name
+  checker_names: list[str]     # Checkers used in this run
+  runtime_policy:              # Deployment runtime policy used for this run
+    network_mode: str          # Network mode: online / offline
+    resource_tier: str         # Resource tier: light / standard / full
+  request:                     # Normalized checker selection request
+    checker_selection_mode: str # Checker selection mode: explicit / recommend / default
+    checker_names: list[str]   # User-specified checkers; usually empty outside explicit mode
+    checker_preferences: str   # Natural-language preferences for recommend mode
+  capability_set:              # Checker availability boundary for this run
+    allowed_checker_names: list[str]  # Checker names allowed by runtime policy
+    blocked_checkers:          # Checkers blocked by policy and their reasons
+      - name: str              # Blocked checker name
+        reasons: list[str]     # Block reason codes
+  resolved_plan:               # Final resolved execution plan
+    schema_version: security_audit.resolved_plan.v1  # Execution plan schema version
+    strategy: deterministic | llm  # Plan resolution strategy; current implementation uses deterministic rules
+    source: explicit | default | recommend | fallback  # Plan source
+    stages:                    # Execution stages; current version runs one stage
+      - id: stage_1            # Unique stage id
+        name: single_stage     # Stage name
+        type: single_stage     # Stage type
+        checkers: list[str]    # Checkers executed in this stage
+        input_scope:           # Input sample scope for this stage
+          type: all_samples    # Scope type; all_samples means all input samples
+          source_stage_id: null # Upstream stage id for multi-stage plans; null for single stage
+        routing:               # Stage routing policy
+          mode: all            # all means run on every sample in the input scope
+    skipped_checkers: list     # Checkers skipped during plan resolution and their reasons
+    degradations: list         # Degradation records from recommendation or planning
+  execution:                   # Actual execution parameters
+    max_workers: int           # Number of parallel workers
+  create_time: str             # Task start time (ISO format)
+  finish_time: str             # Task finish time (ISO format)
   checker_stats:               # Execution statistics per checker
     PIIRule:
       total: int               # Successfully executed count

--- a/docs/tools/security_audit_en.md
+++ b/docs/tools/security_audit_en.md
@@ -103,7 +103,7 @@ This workflow is a default template, not a fixed rule. For partial-risk requests
 | `all_samples` | Run the stage checkers over all samples. | Low-cost rule-based prescreening, or semantic audits that must cover every sample. |
 | `field_applicable` | Only process samples whose fields or dataset type satisfy the checker requirements. | DPO label flipping only runs on `chosen_response` / `rejected_response`; factual consistency only runs when `context` is present; instruction mismatch / sycophancy / self contradiction only run when `response` is present. |
 | `sample` | Run on a sampled subset of applicable samples, controlled by `sample_rate` or `sample_size`. | Low-cost previews, fast risk estimation on very large datasets, or cost control for expensive checkers. |
-| `uncertain` | Route samples from an upstream stage for second-pass review when they match specific rules. | High-recall second scans, boundary-case review, stricter checks for low-confidence results, and compensation for execution errors or content filtering. |
+| `uncertain` | Route samples from an upstream stage for second-pass review when they match specific rules. | High-recall second scans, boundary-case review, stricter checks for low-confidence results, and compensation for execution errors. |
 
 Common `rules` for `uncertain` routing:
 
@@ -220,49 +220,68 @@ results:                       # Raw result from each checker for this sample
 
 ## Example
 
-### Pipeline DSL Example 1: No checkers explicitly specified by the user
+### Pipeline DSL Example 1: `default` mode, use the default checker configuration
 ```python
 
 log_step("Load dataset")
 
 data = load_dataset("dataset")
 
-log_step("Run security audit")
+log_step("Run security audit with default checkers")
 
 audit = run_tool(
     "security_audit",
-    data=data
+    data=data,
+    checker_selection_mode="default"
 )
 
 save_result(audit)
 
 ```
 
-### Pipeline DSL Example 2: Checkers explicitly specified by the user
+### Pipeline DSL Example 2: `explicit` mode, explicitly specify enabled checkers
+
 ```python
 
 log_step("Load dataset")
 
 data = load_dataset("dataset")
 
-log_step("Run security audit with all LLM-based checkers")
+log_step("Run security audit with HarmfulContentLLMJudge")
 
 audit = run_tool(
     "security_audit",
     data=data,
+    checker_selection_mode="explicit",
     checker_names=[
         "HarmfulContentLLMJudge",
-        "BiasLLMJudge",
-        "ToxicityLLMJudge",
-        "PIILLMJudge",
-        "JailbreakLLMJudge",
-        "PromptInjectionLLMJudge",
-        "SelfContradictionLLMJudge",
-        "InstructionMismatchLLMJudge",
-        "FactualInconsistancyLLMJudge",
-        "SycophancyLLMJudge",
-        "DPOLabelFlipLLMJudge",
     ]
+)
+
+save_result(audit)
+
+```
+
+### Pipeline DSL Example 3: `recommend` mode, recommend checkers from the audit intent
+```python
+
+log_step("Load dataset")
+
+data = load_dataset("dataset")
+
+log_step("Run security audit with recommended checkers")
+
+audit = run_tool(
+    "security_audit",
+    data=data,
+    checker_selection_mode="recommend",
+    audit_intent=(
+        "Run a high-recall pre-release security audit for mixed "
+        "SFT and DPO training data. Focus on harmful content, "
+        "PII, secret leakage, prompt injection, jailbreaks. "
+        "Start with a fast prescreen, then semantically review high-risk "
+        "or uncertain samples."
+    )
 )
 
 save_result(audit)

--- a/docs/tools/security_audit_en.md
+++ b/docs/tools/security_audit_en.md
@@ -301,11 +301,13 @@ model_paths:
 
 ## Dependencies
 
-| Dependency | Purpose | Required |
-|------------|---------|----------|
-| `torch` + `transformers` | Model-Based Checker inference | Required when Model-Based Checkers are enabled |
-| LLM API (OpenAI-compatible) | Internal LLM calls | Required when LLM-as-a-Judge Checkers are enabled |
-| GPU | Accelerate Model-Based Checkers | No (CPU supported, but slower) |
+The table below summarizes `security_audit` dependency requirements by resource tier. Higher tiers expose a larger dependency and checker pool, enabling more complex audit strategies. A resource tier only describes the deployment capability ceiling; the actual run still depends on the strategy resolver or user-selected checkers.
+
+| Resource mode | LLM API / local LLM | Local model cache | GPU | Extra dependencies | Available checkers | Supported strategies |
+|---------------|---------------------|-------------------|-----|--------------------|--------------------|----------------------|
+| `light` | Not required | Not required | Not required | Low dependency footprint | all rule-based checkers: `PIIRule`, `SecretRule`, `ToxicityKeywordRule`, `HarmfulKeywordRule`, `BiasKeywordRule` | Batch scanning; fast pre-screening; detect explicit PII, secrets, and obvious harmful/toxic/bias keywords. |
+| `standard` | Required | Optional; CPU-runnable models are allowed | Not required | Requires an LLM provider; `PIINERDetector` requires NER-related dependencies when enabled | all `light` checkers + all LLM-as-a-Judge checkers + `PIINERDetector` | All `light` strategies; enhanced privacy detection; semantic safety auditing; routine pre-ingestion auditing. |
+| `full` | Required | Required; heavyweight model paths or caches must be configured | Recommended | Requires `torch`, `transformers`, and model-specific dependencies | all checkers: all `standard` checkers + `HarmfulContentClassifier`, `ToxicityClassifier`, `BiasClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`, `GraCeFulBackdoorDefender` | All `standard` strategies; high-recall auditing; specialist model review; backdoor detection; benchmarking. |
 
 ---
 

--- a/docs/tools/security_audit_zh.md
+++ b/docs/tools/security_audit_zh.md
@@ -93,7 +93,7 @@ LLM resolver 以渐进式风险审计流程作为默认计划模板。`review` �
 这个流程只是默认模板，不是固定规则。对于只覆盖部分风险的需求，LLM 可以裁剪无关阶段或 checker；对于低成本、快速预览、超大规模数据等需求，LLM 可以调整 routing，例如抽样、只深扫高风险样本或优先扫描特定字段。
 
 
-### Routing 模式
+### Routing Modes
 
 `routing` 负责决定每个 stage 实际处理哪些样本。它的价值是把审计从“所有 checker 全量扫所有样本”变成“按风险、字段、成本和上游结果动态分发样本”，从而在成本可控的前提下提升覆盖率、召回率和判断可信度。
 
@@ -102,7 +102,7 @@ LLM resolver 以渐进式风险审计流程作为默认计划模板。`review` �
 | `all_samples` | 全量运行该 stage 的 checker。 | 低成本 rule-based 预筛，或需要覆盖全部样本的语义审计。 |
 | `field_applicable` | 只处理字段或数据类型满足条件的样本。 | DPO label flipping 只跑 `chosen_response` / `rejected_response`，factual consistency 只跑有 `context` 的样本，instruction mismatch / sycophancy / self contradiction 只跑有 `response` 的样本。 |
 | `sample` | 在满足字段条件的样本中抽样运行，可通过 `sample_rate` 或 `sample_size` 控制规模。 | 低成本预览、超大规模数据快速估计风险、昂贵 checker 控成本。 |
-| `uncertain` | 基于上游 stage 的结果做二次路由，只复核满足规则的样本。 | 高召回二扫、边界样本复核、低置信度样本加严、执行失败或内容过滤样本补偿。 |
+| `uncertain` | 基于上游 stage 的结果做二次路由，只复核满足规则的样本。 | 高召回二扫、边界样本复核、低置信度样本加严、执行失败样本补偿。 |
 
 `uncertain` 模式常用 `rules`：
 
@@ -213,49 +213,67 @@ results:                       # 每个 checker 针对本条样本的原始结�
 
 ## Example
 
-### Pipeline DSL 示例 1：用户在需求中未显式指定启用哪些checker
+### Pipeline DSL 示例 1：`default` 模式，使用默认 checker 配置
 ```python
 
 log_step("Load dataset")
 
 data = load_dataset("dataset")
 
-log_step("Run security audit")
+log_step("Run security audit with default checkers")
 
 audit = run_tool(
     "security_audit",
-    data=data
+    data=data,
+    checker_selection_mode="default"
 )
 
 save_result(audit)
 
 ```
 
-### Pipeline DSL 示例 2：用户在需求中显式指定了启用哪些checker
+### Pipeline DSL 示例 2：`explicit` 模式，用户显式指定启用哪些 checker
 ```python
 
 log_step("Load dataset")
 
 data = load_dataset("dataset")
 
-log_step("Run security audit with all LLM-based checkers")
+log_step("Run security audit with HarmfulContentLLMJudge")
 
 audit = run_tool(
     "security_audit",
     data=data,
+    checker_selection_mode="explicit",
     checker_names=[
         "HarmfulContentLLMJudge",
-        "BiasLLMJudge",
-        "ToxicityLLMJudge",
-        "PIILLMJudge",
-        "JailbreakLLMJudge",
-        "PromptInjectionLLMJudge",
-        "SelfContradictionLLMJudge",
-        "InstructionMismatchLLMJudge",
-        "FactualInconsistancyLLMJudge",
-        "SycophancyLLMJudge",
-        "DPOLabelFlipLLMJudge",
     ]
+)
+
+save_result(audit)
+
+```
+
+### Pipeline DSL 示例 3：`recommend` 模式，根据审计意图推荐 checker
+```python
+
+log_step("Load dataset")
+
+data = load_dataset("dataset")
+
+log_step("Run security audit with recommended checkers")
+
+audit = run_tool(
+    "security_audit",
+    data=data,
+    checker_selection_mode="recommend",
+    audit_intent=(
+        "Run a high-recall pre-release security audit for mixed "
+        "SFT and DPO training data. Focus on harmful content, "
+        "PII, secret leakage, prompt injection, jailbreaks. "
+        "Start with a fast prescreen, then semantically review high-risk "
+        "or uncertain samples."
+    )
 )
 
 save_result(audit)

--- a/docs/tools/security_audit_zh.md
+++ b/docs/tools/security_audit_zh.md
@@ -302,11 +302,13 @@ model_paths:
 
 ## Dependencies
 
-| 依赖 | 用途 | 是否必须 |
-|------|------|----------|
-| `torch` + `transformers` | Model-Based Checkers 推理 | 启用 Model-Based Checkers 时必须 |
-| LLM API（OpenAI 兼容） | 工具内部 LLM 调用 | 启用 LLM-as-a-judge Checkers 时必须 |
-| GPU | Model-Based Checkers 加速 | 否（CPU 可运行，速度较慢） |
+下表按资源档位汇总 `security_audit` 的依赖需求：档位越高，可用依赖和 checker 池越完整，也能支持更复杂的审计策略。资源档位只表示部署环境的能力上限，实际运行时仍由策略解析器或用户指定的 checker 选择决定。
+
+| 资源模式 | LLM API / 本地 LLM | 本地模型缓存 | GPU | 额外依赖 | 可供选择的 checker | 可以跑的策略 |
+|----------|---------------------|--------------|-----|----------|--------------------|--------------|
+| `light` | 不需要 | 不需要 | 不需要 | 低依赖 | all rule-based checkers：`PIIRule`, `SecretRule`, `ToxicityKeywordRule`, `HarmfulKeywordRule`, `BiasKeywordRule` | 批量扫描；快速预筛；发现显式 PII、密钥、明显有害/毒性/偏见关键词。 |
+| `standard` | 需要 | 可选，允许 CPU 可运行模型 | 不需要 | 需要 LLM provider；启用 `PIINERDetector` 时需要 NER 相关依赖 | `light` 全部 checker + all LLM-as-a-judge checkers + `PIINERDetector` | `light` 模式下的所有策略；隐私识别增强；语义安全审计；常规入库前审计。 |
+| `full` | 需要 | 需要，需配置重模型路径或缓存 | 建议使用 | 需要 `torch`、`transformers` 及对应模型依赖 | all checkers：`standard` 全部 checker + `HarmfulContentClassifier`, `ToxicityClassifier`, `BiasClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`, `GraCeFulBackdoorDefender` | `standard` 模式下的所有策略；高召回率审计；专用模型复核；后门检测；benchmark。 |
 
 ---
 

--- a/docs/tools/security_audit_zh.md
+++ b/docs/tools/security_audit_zh.md
@@ -69,8 +69,28 @@
 | `data` | `list[dict]` | 是 | — | 待审计的数据集记录列表 |
 | `checker_selection_mode` | `str` | 否 | `default` | checker 选择意图：`explicit`、`recommend` 或 `default` |
 | `checker_names` | `list[str]` | 否 | `[]` | `explicit` 模式使用的 Checker 类名列表；未传 `checker_selection_mode` 但传了本字段时，按 `explicit` 处理，见 [Checkers](#checkers) |
-| `checker_preferences` | `str` | 否 | `""` | `recommend` 模式使用的自然语言偏好，例如低成本、快速、高准确率或覆盖更强 |
+| `audit_intent` | `str` | 否 | `""` | `recommend` 模式使用的自然语言审计意图，可描述风险聚焦、检测目标、审计范围，以及低成本、快速、高准确率、强覆盖等约束 |
 | `max_workers` | `int` | 否 | `4` | 并行执行的线程数 |
+
+## Resolver
+
+Resolver 负责把 agent 传入的 checker 选择意图解析成可执行的审计计划。它的职责包括：在当前 `capability_set` 边界内选择 checker、组织审计阶段、设计样本路由策略，并在目标无法完全满足时记录确定性的降级原因。
+
+当前支持三类解析路径：
+
+- `explicit`：用户显式指定 `checker_names` 时，按确定性逻辑启用这些 checker，并过滤掉当前运行策略不允许的项。
+- `default`：用户未提出推荐意图时，按默认配置解析 checker。
+- `recommend`：用户希望工具根据自然语言审计意图自动选择和编排 checker 时，进入 LLM resolver。LLM resolver 会结合 `audit_intent`、运行策略和 capability set 生成计划；如果 LLM 不可用或输出不可解析，则降级到确定性 fallback，并在 `degradations` 中记录原因。
+
+LLM resolver 以渐进式风险审计流程作为默认计划模板。`review` 不是必经阶段，而是由上游结果条件触发的复核阶段。
+
+| 阶段 | 目标 | 典型 checker / 能力 | 路由意图 |
+|------|------|--------------------|----------|
+| `quick_scan` | 先用低成本方式做全量预筛，发现 PII、密钥、明显有害/毒性/偏见等表层风险 | `PIIRule`, `SecretRule`, keyword rules, `PIILLMJudge`, `PIINERDetector` | 默认全量运行 |
+| `semantic_scan` | 对有害、毒性、偏见、越狱、提示注入、标签翻转、事实偏离等语义风险进行判断 | LLM judge 系列 checker | 可全量、抽样或按字段适用性路由 |
+| `deep_scan` | 在资源允许时运行高成本专项深扫，覆盖后门、越狱、提示注入、有害内容、毒性等需要专有模型增强判断的风险 | `GraCeFulBackdoorDefender`, `HarmfulContentClassifier`, `ToxicityClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`等 | 抽样、高风险分区、上游命中样本或用户指定范围优先 |
+
+这个流程只是默认模板，不是固定规则。对于只覆盖部分风险的需求，LLM 可以裁剪无关阶段或 checker；对于低成本、快速预览、超大规模数据等需求，LLM 可以调整 routing，例如抽样、只深扫高风险样本或优先扫描特定字段。
 
 
 
@@ -89,7 +109,7 @@ result:
       total: int               # 检测该风险的样本总数
       flagged: int             # 命中数
     harmful: {total: int, flagged: int}
-    # ... 其他风险类型（共 14 种）
+    # ... 其他风险类型（共 13 种）
   checker_stats:               # 每个 checker 的执行统计
     PIIRule:
       total: int               # 成功执行数
@@ -101,33 +121,32 @@ metadata:
   task_name: str               # 审计任务名称
   checker_names: list[str]     # 本次运行使用的 checker 列表
   runtime_policy:              # 本次运行使用的部署运行策略
-    network_mode: str          # 网络模式：online / offline
-    resource_tier: str         # 资源档位：light / standard / full
+    network_mode: online | offline  # 网络模式
+    resource_tier: light | standard | full # 资源档位
   request:                     # 归一化后的 checker 选择请求
-    checker_selection_mode: str # checker 选择模式：explicit / recommend / default
+    checker_selection_mode: explicit | recommend | default # checker 选择模式
     checker_names: list[str]   # 用户显式指定的 checker 列表；非 explicit 时通常为空
-    checker_preferences: str   # recommend 模式下的自然语言偏好
+    audit_intent: str          # recommend 模式下的自然语言审计意图，包括风险聚焦、检测目标、范围和成本/质量约束
   capability_set:              # 根据运行策略计算出的本次可用 checker 边界
     allowed_checker_names: list[str]  # 本次允许运行的 checker 名称
     blocked_checkers:          # 本次被策略排除的 checker 及原因
       - name: str              # 被排除的 checker 名称
         reasons: list[str]     # 排除原因代码列表
   resolved_plan:               # 最终解析出的执行计划
-    schema_version: security_audit.resolved_plan.v1  # 执行计划结构版本
-    strategy: deterministic | llm  # 计划解析策略；当前实现使用 deterministic 规则
+    schema_version: security_audit.resolved_plan.v1 # 执行计划结构版本
+    strategy: deterministic | llm  # 计划解析策略；recommend 模式下 llm 可产出渐进式风险审计流程计划
     source: explicit | default | recommend | fallback  # 计划来源
-    stages:                    # 执行阶段列表；当前版本仍为单阶段
-      - id: stage_1            # 阶段唯一标识
-        name: single_stage     # 阶段名称
-        type: single_stage     # 阶段类型
+    objective: dict            # llm 解析出的审计目标、覆盖风险和优化偏好
+    stages:                    # 解析出的阶段列表；llm 策略可返回多阶段计划
+      - id: str                # 阶段唯一标识，例如 stage_1
+        name: str              # 阶段名称，例如 single_stage / quick_scan
+        type: str              # 阶段类型，例如 single_stage / semantic_scan
         checkers: list[str]    # 该阶段运行的 checker 列表
-        input_scope:           # 该阶段输入样本范围
-          type: all_samples    # 输入范围类型；all_samples 表示全部样本
-          source_stage_id: null # 多阶段场景下的上游阶段 ID；单阶段为 null
         routing:               # 阶段路由策略
-          mode: all            # all 表示对输入范围内全部样本运行
-    skipped_checkers: list     # 解析计划时被跳过的 checker 及原因
-    degradations: list         # 推荐或规划过程中发生的降级记录
+          mode: all_samples | field_applicable | uncertain | sample | high_risk_partition # 路由模式
+          source_stage_id: str | null # 依赖上游阶段结果时填写真实阶段 ID，例如 stage_2；单阶段为 null
+    skipped_checkers: list[dict] # 解析计划时被跳过的 checker 及原因
+    degradations: list[dict]   # 推荐或规划过程中发生的降级记录
   execution:                   # 实际执行参数
     max_workers: int           # 并行 worker 数
   create_time: str             # 任务开始时间（ISO 格式）
@@ -262,6 +281,7 @@ save_result(audit)
 | `PIINERDetector` | `pii` | Microsoft presidio NER 模型 | PII泄露 |
 | `JailbreakClassifier` | `jailbreak` | `allenai/WildGuard`| 越狱提示 |
 | `PromptInjectionClassifier` | `prompt_injection` | `leolee99/PIGuard` | 提示注入 |
+| `CrossModelRiskReviewer` | `jailbreak`, `prompt_injection`, `harmful`, `toxicity` | Llama Guard, PIGuard, WildGuard, Qwen-Guard-Gen | 多模型交叉复核 |
 
 ### Heuristic Checkers
 
@@ -340,7 +360,7 @@ model_paths:
 |----------|---------------------|--------------|-----|----------|--------------------|--------------|
 | `light` | 不需要 | 不需要 | 不需要 | 低依赖 | all rule-based checkers：`PIIRule`, `SecretRule`, `ToxicityKeywordRule`, `HarmfulKeywordRule`, `BiasKeywordRule` | 批量扫描；快速预筛；发现显式 PII、密钥、明显有害/毒性/偏见关键词。 |
 | `standard` | 需要 | 可选，允许 CPU 可运行模型 | 不需要 | 需要 LLM provider；启用 `PIINERDetector` 时需要 NER 相关依赖 | `light` 全部 checker + all LLM-as-a-judge checkers + `PIINERDetector` | `light` 模式下的所有策略；隐私识别增强；语义安全审计；常规入库前审计。 |
-| `full` | 需要 | 需要，需配置重模型路径或缓存 | 建议使用 | 需要 `torch`、`transformers` 及对应模型依赖 | all checkers：`standard` 全部 checker + `HarmfulContentClassifier`, `ToxicityClassifier`, `BiasClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`, `GraCeFulBackdoorDefender` | `standard` 模式下的所有策略；高召回率审计；专用模型复核；后门检测；benchmark。 |
+| `full` | 需要 | 需要，需配置重模型路径或缓存 | 建议使用 | 需要 `torch`、`transformers` 及对应模型依赖 | all checkers：`standard` 全部 checker + `HarmfulContentClassifier`, `ToxicityClassifier`, `BiasClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`, `CrossModelRiskReviewer`, `GraCeFulBackdoorDefender` | `standard` 模式下的所有策略；高召回率审计；专用模型复核；后门检测；benchmark。 |
 
 ---
 

--- a/docs/tools/security_audit_zh.md
+++ b/docs/tools/security_audit_zh.md
@@ -93,6 +93,29 @@ LLM resolver 以渐进式风险审计流程作为默认计划模板。`review` �
 这个流程只是默认模板，不是固定规则。对于只覆盖部分风险的需求，LLM 可以裁剪无关阶段或 checker；对于低成本、快速预览、超大规模数据等需求，LLM 可以调整 routing，例如抽样、只深扫高风险样本或优先扫描特定字段。
 
 
+### Routing 模式
+
+`routing` 负责决定每个 stage 实际处理哪些样本。它的价值是把审计从“所有 checker 全量扫所有样本”变成“按风险、字段、成本和上游结果动态分发样本”，从而在成本可控的前提下提升覆盖率、召回率和判断可信度。
+
+| 模式 | 说明 | 典型场景 |
+|------|------|----------|
+| `all_samples` | 全量运行该 stage 的 checker。 | 低成本 rule-based 预筛，或需要覆盖全部样本的语义审计。 |
+| `field_applicable` | 只处理字段或数据类型满足条件的样本。 | DPO label flipping 只跑 `chosen_response` / `rejected_response`，factual consistency 只跑有 `context` 的样本，instruction mismatch / sycophancy / self contradiction 只跑有 `response` 的样本。 |
+| `sample` | 在满足字段条件的样本中抽样运行，可通过 `sample_rate` 或 `sample_size` 控制规模。 | 低成本预览、超大规模数据快速估计风险、昂贵 checker 控成本。 |
+| `uncertain` | 基于上游 stage 的结果做二次路由，只复核满足规则的样本。 | 高召回二扫、边界样本复核、低置信度样本加严、执行失败或内容过滤样本补偿。 |
+
+`uncertain` 模式常用 `rules`：
+
+| 规则 | 说明 |
+|------|------|
+| `near_threshold` | 只复核分数接近判定阈值的边界样本，避免临界风险被误放或误杀。 |
+| `low_confidence` | 只复核 checker 置信度较低的样本，用更强判断补足不确定结论。 |
+| `conflicting` | 只复核多个 checker 结论不一致的样本，用于仲裁冲突、提升最终可信度。 |
+| `error` | 只复核上游 checker 执行失败的样本，避免因为工具异常造成漏检。 |
+| `content_filter` | 只复核触发内容过滤的样本，避免高风险内容因 LLM 拒答或过滤而缺少审计结论。 |
+| `unflagged` | 只复核上游未命中的样本，适合高召回二扫，尽量捞回漏检风险。 |
+
+
 
 ## Output
 
@@ -143,8 +166,15 @@ metadata:
         type: str              # 阶段类型，例如 single_stage / semantic_scan
         checkers: list[str]    # 该阶段运行的 checker 列表
         routing:               # 阶段路由策略
-          mode: all_samples | field_applicable | uncertain | sample | high_risk_partition # 路由模式
+          mode: all_samples | field_applicable | uncertain | sample # 路由模式
           source_stage_id: str | null # 依赖上游阶段结果时填写真实阶段 ID，例如 stage_2；单阶段为 null
+          rules: list[str]     # uncertain 模式下的复核规则，例如 near_threshold / low_confidence / conflicting / error / content_filter / unflagged
+          dataset_types: list[str] # 可选，按数据集类型路由，例如 dpo / sft / rl / benchmark
+          required_fields: list[str] # 可选，按真实 DataSample 字段路由，例如 response / context / chosen_response / rejected_response
+          sample_rate: float   # 可选，sample 模式下的抽样比例，范围 0.0-1.0
+          sample_size: int     # 可选，sample 模式下的最大抽样数量
+          threshold: float     # 可选，near_threshold 使用的判定阈值，默认通常为 0.5
+          threshold_margin: float # 可选，near_threshold 的阈值邻域，例如 0.1
     skipped_checkers: list[dict] # 解析计划时被跳过的 checker 及原因
     degradations: list[dict]   # 推荐或规划过程中发生的降级记录
   execution:                   # 实际执行参数
@@ -281,7 +311,6 @@ save_result(audit)
 | `PIINERDetector` | `pii` | Microsoft presidio NER 模型 | PII泄露 |
 | `JailbreakClassifier` | `jailbreak` | `allenai/WildGuard`| 越狱提示 |
 | `PromptInjectionClassifier` | `prompt_injection` | `leolee99/PIGuard` | 提示注入 |
-| `CrossModelRiskReviewer` | `jailbreak`, `prompt_injection`, `harmful`, `toxicity` | Llama Guard, PIGuard, WildGuard, Qwen-Guard-Gen | 多模型交叉复核 |
 
 ### Heuristic Checkers
 
@@ -360,7 +389,7 @@ model_paths:
 |----------|---------------------|--------------|-----|----------|--------------------|--------------|
 | `light` | 不需要 | 不需要 | 不需要 | 低依赖 | all rule-based checkers：`PIIRule`, `SecretRule`, `ToxicityKeywordRule`, `HarmfulKeywordRule`, `BiasKeywordRule` | 批量扫描；快速预筛；发现显式 PII、密钥、明显有害/毒性/偏见关键词。 |
 | `standard` | 需要 | 可选，允许 CPU 可运行模型 | 不需要 | 需要 LLM provider；启用 `PIINERDetector` 时需要 NER 相关依赖 | `light` 全部 checker + all LLM-as-a-judge checkers + `PIINERDetector` | `light` 模式下的所有策略；隐私识别增强；语义安全审计；常规入库前审计。 |
-| `full` | 需要 | 需要，需配置重模型路径或缓存 | 建议使用 | 需要 `torch`、`transformers` 及对应模型依赖 | all checkers：`standard` 全部 checker + `HarmfulContentClassifier`, `ToxicityClassifier`, `BiasClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`, `CrossModelRiskReviewer`, `GraCeFulBackdoorDefender` | `standard` 模式下的所有策略；高召回率审计；专用模型复核；后门检测；benchmark。 |
+| `full` | 需要 | 需要，需配置重模型路径或缓存 | 建议使用 | 需要 `torch`、`transformers` 及对应模型依赖 | all checkers：`standard` 全部 checker + `HarmfulContentClassifier`, `ToxicityClassifier`, `BiasClassifier`, `JailbreakClassifier`, `PromptInjectionClassifier`, `GraCeFulBackdoorDefender` | `standard` 模式下的所有策略；高召回率审计；专用模型复核；后门检测；benchmark。 |
 
 ---
 

--- a/docs/tools/security_audit_zh.md
+++ b/docs/tools/security_audit_zh.md
@@ -67,7 +67,9 @@
 | 参数 | 类型 | 必填 | 默认值 | 说明 |
 |------|------|------|--------|------|
 | `data` | `list[dict]` | 是 | — | 待审计的数据集记录列表 |
-| `checker_names` | `list[str]` | 否 | `[]` | 根据用户需求指定的的 Checker 类名列表，见 [Checkers](#checkers) |
+| `checker_selection_mode` | `str` | 否 | `default` | checker 选择意图：`explicit`、`recommend` 或 `default` |
+| `checker_names` | `list[str]` | 否 | `[]` | `explicit` 模式使用的 Checker 类名列表；未传 `checker_selection_mode` 但传了本字段时，按 `explicit` 处理，见 [Checkers](#checkers) |
+| `checker_preferences` | `str` | 否 | `""` | `recommend` 模式使用的自然语言偏好，例如低成本、快速、高准确率或覆盖更强 |
 | `max_workers` | `int` | 否 | `4` | 并行执行的线程数 |
 
 
@@ -77,18 +79,11 @@
 ```yaml
 result:
   security_score: float        # 加权安全分数（0.0–1.0，越高越安全）
-  passed: bool                 # security_score >= threshold 时为 true
   total_issues: int            # 被标记为风险的样本数
   flagged_samples: int         # 同 total_issues
   safe_samples: int            # 未被标记的样本数
   total_samples: int           # 总样本数
   flagged_rate: float          # 被标记率（flagged_samples / total_samples）
-
-metadata:
-  task_name: str               # 审计任务名称
-  checker_names: list[str]     # 本次使用的 checker 列表
-  create_time: str             # 任务开始时间（ISO 格式）
-  finish_time: str             # 任务结束时间（ISO 格式）
   risk_distribution:           # 各风险类型的分布统计
     pii:
       total: int               # 检测该风险的样本总数
@@ -101,6 +96,43 @@ metadata:
       flagged: int             # 标记数
       error: int               # 执行异常数
       content_filter: int      # 触发内容过滤数
+
+metadata:
+  task_name: str               # 审计任务名称
+  checker_names: list[str]     # 本次运行使用的 checker 列表
+  runtime_policy:              # 本次运行使用的部署运行策略
+    network_mode: str          # 网络模式：online / offline
+    resource_tier: str         # 资源档位：light / standard / full
+  request:                     # 归一化后的 checker 选择请求
+    checker_selection_mode: str # checker 选择模式：explicit / recommend / default
+    checker_names: list[str]   # 用户显式指定的 checker 列表；非 explicit 时通常为空
+    checker_preferences: str   # recommend 模式下的自然语言偏好
+  capability_set:              # 根据运行策略计算出的本次可用 checker 边界
+    allowed_checker_names: list[str]  # 本次允许运行的 checker 名称
+    blocked_checkers:          # 本次被策略排除的 checker 及原因
+      - name: str              # 被排除的 checker 名称
+        reasons: list[str]     # 排除原因代码列表
+  resolved_plan:               # 最终解析出的执行计划
+    schema_version: security_audit.resolved_plan.v1  # 执行计划结构版本
+    strategy: deterministic | llm  # 计划解析策略；当前实现使用 deterministic 规则
+    source: explicit | default | recommend | fallback  # 计划来源
+    stages:                    # 执行阶段列表；当前版本仍为单阶段
+      - id: stage_1            # 阶段唯一标识
+        name: single_stage     # 阶段名称
+        type: single_stage     # 阶段类型
+        checkers: list[str]    # 该阶段运行的 checker 列表
+        input_scope:           # 该阶段输入样本范围
+          type: all_samples    # 输入范围类型；all_samples 表示全部样本
+          source_stage_id: null # 多阶段场景下的上游阶段 ID；单阶段为 null
+        routing:               # 阶段路由策略
+          mode: all            # all 表示对输入范围内全部样本运行
+    skipped_checkers: list     # 解析计划时被跳过的 checker 及原因
+    degradations: list         # 推荐或规划过程中发生的降级记录
+  execution:                   # 实际执行参数
+    max_workers: int           # 并行 worker 数
+  create_time: str             # 任务开始时间（ISO 格式）
+  finish_time: str             # 任务结束时间（ISO 格式）
+  
 
 artifacts:
   report_md: str               # Markdown 格式的完整审计报告文件路径

--- a/docs/tools/security_audit_zh.md
+++ b/docs/tools/security_audit_zh.md
@@ -170,7 +170,6 @@ metadata:
           source_stage_id: str | null # 依赖上游阶段结果时填写真实阶段 ID，例如 stage_2；单阶段为 null
           rules: list[str]     # uncertain 模式下的复核规则，例如 near_threshold / low_confidence / conflicting / error / content_filter / unflagged
           dataset_types: list[str] # 可选，按数据集类型路由，例如 dpo / sft / rl / benchmark
-          required_fields: list[str] # 可选，按真实 DataSample 字段路由，例如 response / context / chosen_response / rejected_response
           sample_rate: float   # 可选，sample 模式下的抽样比例，范围 0.0-1.0
           sample_size: int     # 可选，sample 模式下的最大抽样数量
           threshold: float     # 可选，near_threshold 使用的判定阈值，默认通常为 0.5

--- a/tools/security_audit/checker/heuristic/graceful_backdoor_detection.py
+++ b/tools/security_audit/checker/heuristic/graceful_backdoor_detection.py
@@ -24,6 +24,34 @@ class GraCeFulBackdoorDefender(HeuristicChecker):
 
     Reference: https://arxiv.org/abs/2412.02454
     """
+    planner_metadata = {
+        "description": (
+            "Heuristic checker for backdoor or poisoned data detection. "
+            "Uses the GraCeFul gradient-based clustering pipeline to identify minority "
+            "samples with suspicious gradient-frequency behavior."
+        ),
+        "required_fields": ["response"],
+        "method": {
+            "type": "heuristic",
+            "pipeline": [
+                "build context/target pairs from each sample in a batch",
+                "load the configured victim language model",
+                "compute target-parameter gradients and DCT frequency features",
+                "reduce feature dimensionality with PCA",
+                "cluster samples and flag the minority cluster as suspicious",
+            ],
+        },
+        "cost_profile": {
+            "cost": "high",
+            "latency": "high",
+            "execution": "batch",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def __init__(
         self,

--- a/tools/security_audit/checker/llm_judge/bias_judge.py
+++ b/tools/security_audit/checker/llm_judge/bias_judge.py
@@ -81,6 +81,33 @@ class BiasLLMJudge(LLMJudgeChecker):
         using the four-category rubric in BiasTemplate (gender, political,
         racial/ethnic, geographical).
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for biased language. "
+            "Evaluates statements for gender, political, racial or ethnic, "
+            "and geographical bias."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "format all available sample text fields into a single content block",
+                "extract distinct statements with an LLM",
+                "judge each extracted statement against a bias rubric",
+                "score by the fraction of biased statements with square-root scaling",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/bias_judge.py
+++ b/tools/security_audit/checker/llm_judge/bias_judge.py
@@ -91,7 +91,7 @@ class BiasLLMJudge(LLMJudgeChecker):
 
         content = format_content(sample)
         if not content:
-            self._log.warning("BiasLLMJudge: no content to analyze, skipping.")
+            self._log.warning(f"BiasLLMJudge: no content to analyze in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"skipped": "no content to analyze"})
 
         # Step 1: extract opinions from all text fields

--- a/tools/security_audit/checker/llm_judge/dpo_label_flip_judge.py
+++ b/tools/security_audit/checker/llm_judge/dpo_label_flip_judge.py
@@ -202,6 +202,33 @@ class DPOLabelFlipLLMJudge(LLMJudgeChecker):
     Step 1 — Score each response independently on quality dimensions (0/1).
     Step 2 — When quality scores are tied, run a direct pairwise comparison.
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for DPO label flipping. "
+            "Detects cases where the rejected response appears preferable to the chosen response."
+        ),
+        "required_fields": ["chosen_response", "rejected_response"],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "skip non-DPO samples",
+                "extract the instruction plus chosen and rejected responses",
+                "score each response independently for training quality",
+                "run pairwise comparison when independent scores are tied",
+                "flag hard flips and pairwise flips where rejected is preferred",
+            ],
+        },
+        "cost_profile": {
+            "cost": "high",
+            "latency": "high",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/dpo_label_flip_judge.py
+++ b/tools/security_audit/checker/llm_judge/dpo_label_flip_judge.py
@@ -213,7 +213,7 @@ class DPOLabelFlipLLMJudge(LLMJudgeChecker):
         rejected = sample.rejected_response.content if sample.rejected_response else ""
 
         if not chosen or not rejected:
-            self._log.warning("DPOLabelFlipLLMJudge: missing chosen or rejected response, skipping.")
+            self._log.warning(f"DPOLabelFlipLLMJudge: missing chosen or rejected response in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False,
                                details={"error": "missing chosen_response or rejected_response"})
 

--- a/tools/security_audit/checker/llm_judge/factual_inconsistancy_judge.py
+++ b/tools/security_audit/checker/llm_judge/factual_inconsistancy_judge.py
@@ -85,6 +85,32 @@ class FactualInconsistancyLLMJudge(LLMJudgeChecker):
     Compares the response against provided context strings to
     detect contradictions.
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for factual inconsistency and hallucination. "
+            "Compares an assistant response against provided context strings and detects contradictions."
+        ),
+        "required_fields": ["context"],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "extract the assistant response and context strings",
+                "judge whether the response agrees with each provided context",
+                "count contradictions and factual alignments",
+                "score by the fraction of contradictory context verdicts with square-root scaling",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/factual_inconsistancy_judge.py
+++ b/tools/security_audit/checker/llm_judge/factual_inconsistancy_judge.py
@@ -97,7 +97,7 @@ class FactualInconsistancyLLMJudge(LLMJudgeChecker):
         contexts = self._extract_contexts(sample)
 
         if not response or not contexts:
-            self._log.warning("FactualInconsistancyLLMJudge: missing response or contexts, skipping.")
+            self._log.warning(f"FactualInconsistancyLLMJudge: missing response or contexts in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"error": "missing response or contexts"})
 
         # Step 1: get per-context verdicts

--- a/tools/security_audit/checker/llm_judge/harmful_judge.py
+++ b/tools/security_audit/checker/llm_judge/harmful_judge.py
@@ -77,6 +77,33 @@ class HarmfulContentLLMJudge(LLMJudgeChecker):
     Step 2 — Verdict evaluation: judge each statement against a harmful content rubric
               (violence, illegal activities, self-harm, abuse/exploitation).
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for harmful content. "
+            "Evaluates statements for violence, weapons, illegal activity, self-harm, "
+            "abuse, and exploitation risks."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "format all available sample text fields into a single content block",
+                "extract distinct statements with an LLM",
+                "judge each extracted statement against a harmful-content rubric",
+                "score by the fraction of harmful statements with square-root scaling",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/harmful_judge.py
+++ b/tools/security_audit/checker/llm_judge/harmful_judge.py
@@ -87,7 +87,7 @@ class HarmfulContentLLMJudge(LLMJudgeChecker):
 
         content = format_content(sample)
         if not content:
-            self._log.warning("HarmfulContentLLMJudge: no content to analyze, skipping.")
+            self._log.warning(f"HarmfulContentLLMJudge: no content to analyze in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"error": "no content to analyze"})
 
         try:

--- a/tools/security_audit/checker/llm_judge/helper.py
+++ b/tools/security_audit/checker/llm_judge/helper.py
@@ -50,5 +50,34 @@ def extract_response(sample: DataSample) -> str:
 
 
 def is_content_filter_error(err_msg: str) -> bool:
-    """Check whether an error message indicates a content filter rejection."""
-    return "content_filter" in err_msg or "content management policy" in err_msg
+    """Check whether an error message indicates a provider safety rejection."""
+    if not err_msg:
+        return False
+
+    msg = err_msg.lower()
+
+    exact_indicators = (
+        # OpenAI / Azure OpenAI / compatible gateways
+        "content_filter",
+        "content management policy",
+        "content policy violation",
+        "content_policy_violation",
+        "safety system",
+        # Anthropic Claude
+        "safety policy",
+        "acceptable use policy",
+        "input blocked",
+        "output blocked",
+        # Qwen / DashScope and other moderation gateways
+        "data inspection failed",
+        "inappropriate content",
+        "input data may contain inappropriate content",
+        "output data may contain inappropriate content",
+        "sensitive information",
+    )
+    if any(indicator in msg for indicator in exact_indicators):
+        return True
+
+    moderation_terms = ("moderation", "moderated", "safety", "policy", "unsafe", "sensitive")
+    rejection_terms = ("blocked", "rejected", "refused", "disallowed", "prohibited", "violat")
+    return any(term in msg for term in moderation_terms) and any(term in msg for term in rejection_terms)

--- a/tools/security_audit/checker/llm_judge/instruction_mismatch_judge.py
+++ b/tools/security_audit/checker/llm_judge/instruction_mismatch_judge.py
@@ -149,7 +149,7 @@ class InstructionMismatchLLMJudge(LLMJudgeChecker):
 
         # If there are no instructions or no response, we consider it a pass (no mismatch) rather than a fail, since there's nothing to be misaligned.
         if not response or not instructions:
-            self._log.warning("InstructionMismatchLLMJudge: no instructions or response found, skipping.")
+            self._log.warning(f"InstructionMismatchLLMJudge: no instructions or response found in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"error": "missing response or instructions"})
         
         if instructions == []:

--- a/tools/security_audit/checker/llm_judge/instruction_mismatch_judge.py
+++ b/tools/security_audit/checker/llm_judge/instruction_mismatch_judge.py
@@ -137,6 +137,33 @@ class InstructionMismatchLLMJudge(LLMJudgeChecker):
       - user messages that contain explicit instructions/requirements
     """
 
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for instruction mismatch (prompt alignment)."
+            "Checks whether an assistant response follows explicit, benign system "
+            "and user instructions, including concrete requirements and prohibitions."
+        ),
+        "required_fields": ["messages", "response"],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "extract explicit benign instructions from system/user messages",
+                "judge each extracted instruction against the assistant response",
+                "score by the fraction of violated instructions with square-root scaling",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
+
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)
 

--- a/tools/security_audit/checker/llm_judge/jailbreak_judge.py
+++ b/tools/security_audit/checker/llm_judge/jailbreak_judge.py
@@ -87,7 +87,7 @@ class JailbreakLLMJudge(LLMJudgeChecker):
 
         query, response = self._extract_query_response(sample)
         if not query:
-            self._log.warning("JailbreakLLMJudge: missing user query, skipping.")
+            self._log.warning(f"JailbreakLLMJudge: missing user query in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"error": "missing user query"})
 
         try:

--- a/tools/security_audit/checker/llm_judge/jailbreak_judge.py
+++ b/tools/security_audit/checker/llm_judge/jailbreak_judge.py
@@ -77,6 +77,33 @@ class JailbreakLLMJudge(LLMJudgeChecker):
     Sends the user prompt and assistant response to an LLM judge that scores
     the jailbreak risk on a 0.0-1.0 scale.
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for jailbreak risk. "
+            "Evaluates whether a user prompt or assistant response bypasses safety, "
+            "ethics, or legal constraints and yields prohibited harmful content."
+        ),
+        "required_fields": ["messages"],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "extract the last user query and available assistant response",
+                "ask an LLM judge to reason about prompt risk and response safety",
+                "parse the required bracketed score from the judge output",
+                "flag when the jailbreak risk score meets the threshold",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/pii_judge.py
+++ b/tools/security_audit/checker/llm_judge/pii_judge.py
@@ -63,6 +63,33 @@ class PIILLMJudge(LLMJudgeChecker):
     Step 2 — Verdict evaluation: judge each statement for actual PII/privacy
               violations (names, contact info, IDs, financial/medical data, etc.).
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for PII and privacy leakage. "
+            "Evaluates text for personal identifiers, contact data, government IDs, "
+            "financial or medical records, and confidential personal information."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "format all available sample text fields into a single content block",
+                "extract statements that may contain PII or privacy-sensitive content",
+                "judge each extracted statement for actual PII/privacy leakage",
+                "score by the fraction of confirmed PII statements with square-root scaling",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/pii_judge.py
+++ b/tools/security_audit/checker/llm_judge/pii_judge.py
@@ -74,9 +74,8 @@ class PIILLMJudge(LLMJudgeChecker):
 
         content = format_content(sample)
         if not content:
-            self._log.warning("PIILLMJudge: no content to analyze, skipping.")
-            return CheckResult(**base, success=False,
-                               details={"error": "no content to analyze"})
+            self._log.warning(f"PIILLMJudge: no content to analyze in sample {sample.id}, skipping.")
+            return CheckResult(**base, success=False, details={"error": "no content to analyze"})
 
         # Step 1: extract statements
         try:

--- a/tools/security_audit/checker/llm_judge/prompt_injection_judge.py
+++ b/tools/security_audit/checker/llm_judge/prompt_injection_judge.py
@@ -89,8 +89,7 @@ class PromptInjectionLLMJudge(LLMJudgeChecker):
 
         if not self.llm:
             self._log.warning("PromptInjectionLLMJudge: no LLM client available, skipping.")
-            return CheckResult(**base, success=False,
-                               details={"error": "llm not configured"})
+            return CheckResult(**base, success=False, details={"error": "llm not configured"})
 
         user_texts = []
         for m in sample.messages:
@@ -99,7 +98,7 @@ class PromptInjectionLLMJudge(LLMJudgeChecker):
 
         user_text = "\n".join(user_texts)
         if not user_text:
-            self._log.warning("PromptInjectionLLMJudge: missing user text, skipping.")
+            self._log.warning(f"PromptInjectionLLMJudge: missing user text in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"error": "missing user text"})
 
         try:
@@ -113,7 +112,7 @@ class PromptInjectionLLMJudge(LLMJudgeChecker):
                 return CheckResult(**base, success=False, details={"error": str(e)})
             # The full prompt (with examples) triggered a content filter — retry with a minimal prompt
             # to determine whether the filter was triggered by the examples or the user input itself.
-            self._log.info("PromptInjectionLLMJudge: content filter hit on full prompt, retrying with minimal prompt.")
+            self._log.info(f"PromptInjectionLLMJudge: content filter hit on full prompt in sample {sample.id}, retrying with minimal prompt.")
             try:
                 fallback = _DETECT_PI_PROMPT_MINIMAL.format(user_input=user_text)
                 raw = self.llm.generate(model=self.llm_model, prompt=fallback)
@@ -124,7 +123,7 @@ class PromptInjectionLLMJudge(LLMJudgeChecker):
                     # Both prompts triggered the filter: the user input itself is the cause.
                     # This indicates harmful/unsafe content, but NOT necessarily prompt injection.
                     # Mark as inconclusive rather than assuming injection.
-                    self._log.info("PromptInjectionLLMJudge: user input triggers content filter")
+                    self._log.info(f"PromptInjectionLLMJudge: user input in sample {sample.id} triggers content filter")
                     return CheckResult(**base, success=False, details={"error": str(e2), "content_filter_triggered": True})
                 self._log.warning(f"PromptInjectionLLMJudge: fallback also failed on sample {sample.id}: {e2}")
                 return CheckResult(**base, success=False, details={"error": str(e2)})

--- a/tools/security_audit/checker/llm_judge/prompt_injection_judge.py
+++ b/tools/security_audit/checker/llm_judge/prompt_injection_judge.py
@@ -83,6 +83,33 @@ class PromptInjectionLLMJudge(LLMJudgeChecker):
     Sends user-role message text to an LLM with a scoring prompt adapted from
     the rebuff project. The LLM returns a 0.0–1.0 injection likelihood score.
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for prompt injection attempts. "
+            "Scores user messages for attempts to override instructions, redirect behavior, "
+            "or induce unsafe tool or policy bypasses."
+        ),
+        "required_fields": ["messages"],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "collect all user-role message text",
+                "ask an LLM judge for a prompt-injection likelihood score from 0.0 to 1.0",
+                "retry with a minimal prompt if the full prompt triggers a content filter",
+                "flag when the score meets the prompt injection threshold",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/self_contradiction_judge.py
+++ b/tools/security_audit/checker/llm_judge/self_contradiction_judge.py
@@ -98,6 +98,32 @@ class SelfContradictionLLMJudge(LLMJudgeChecker):
 
     Score = number_of_contradictions / total_claims  (0 = fully consistent).
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for self-contradiction in assistant responses. "
+            "Detects mutually inconsistent factual claims inside a single response."
+        ),
+        "required_fields": ["response"],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "extract the assistant response from response, chosen_response, or assistant messages",
+                "extract explicit factual claims from the response",
+                "judge whether any claim pairs contradict each other",
+                "score by the fraction of contradictory claims with square-root scaling",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/self_contradiction_judge.py
+++ b/tools/security_audit/checker/llm_judge/self_contradiction_judge.py
@@ -109,7 +109,7 @@ class SelfContradictionLLMJudge(LLMJudgeChecker):
         response = extract_response(sample)
 
         if not response:
-            self._log.warning("SelfContradictionLLMJudge: missing actual output, skipping.")
+            self._log.warning(f"SelfContradictionLLMJudge: missing actual output in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"error": "missing response"})
 
         # Step 1: extract claims from the response

--- a/tools/security_audit/checker/llm_judge/sycophancy_judge.py
+++ b/tools/security_audit/checker/llm_judge/sycophancy_judge.py
@@ -198,8 +198,8 @@ class SycophancyLLMJudge(LLMJudgeChecker):
 
         question, response = self._extract_query_response(sample)
         if not question:
-            return CheckResult(**base, success=False,
-                               details={"error": "missing user query"})
+            self._log.warning(f"SycophancyLLMJudge: missing user query in sample {sample.id}, skipping.")
+            return CheckResult(**base, success=False, details={"error": "missing user query"})
 
         scores = self._evaluate_turn(question, response, self.llm, self.llm_model)
 

--- a/tools/security_audit/checker/llm_judge/sycophancy_judge.py
+++ b/tools/security_audit/checker/llm_judge/sycophancy_judge.py
@@ -187,6 +187,33 @@ class SycophancyLLMJudge(LLMJudgeChecker):
     Overall score  = mean across all turns (0.0–1.0).
     Flagged when score > 0.5.
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for sycophancy in assistant responses. "
+            "Evaluates whether advice over-validates the user, avoids directness, "
+            "or accepts questionable framing instead of challenging it."
+        ),
+        "required_fields": ["response"],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "extract the last user query and available assistant response",
+                "pre-filter whether the user query presents sycophancy risk",
+                "score validation, indirectness, and framing with separate LLM prompts",
+                "compute a weighted sycophancy score with framing as the dominant signal",
+            ],
+        },
+        "cost_profile": {
+            "cost": "high",
+            "latency": "high",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/toxicity_judge.py
+++ b/tools/security_audit/checker/llm_judge/toxicity_judge.py
@@ -82,6 +82,33 @@ class ToxicityLLMJudge(LLMJudgeChecker):
         using the rubric in ToxicityTemplate (personal attacks, mockery,
         hate, dismissive statements, threats/intimidation).
     """
+    planner_metadata = {
+        "description": (
+            "LLM-as-a-Judge checker for toxicity detection. "
+            "Evaluates statements for personal attacks, mockery, hate, dismissive language, "
+            "and threats or intimidation."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "llm_judge",
+            "pipeline": [
+                "format all available sample text fields into a single content block",
+                "extract distinct statements with an LLM",
+                "judge each extracted statement against a toxicity rubric",
+                "score by the fraction of toxic statements with square-root scaling",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": True,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/llm_judge/toxicity_judge.py
+++ b/tools/security_audit/checker/llm_judge/toxicity_judge.py
@@ -92,7 +92,7 @@ class ToxicityLLMJudge(LLMJudgeChecker):
 
         content = format_content(sample)
         if not content:
-            self._log.warning("ToxicityLLMJudge: no content to analyze, skipping.")
+            self._log.warning(f"ToxicityLLMJudge: no content to analyze in sample {sample.id}, skipping.")
             return CheckResult(**base, success=False, details={"error": "no content to analyze"})
 
         # Step 1: extract statements from all text fields

--- a/tools/security_audit/checker/model_based/bias_classifier.py
+++ b/tools/security_audit/checker/model_based/bias_classifier.py
@@ -24,6 +24,32 @@ class BiasClassifier(ModelBasedChecker):
     Detects 11 bias categories: racial, religious, gender, age, nationality,
     sexuality, socioeconomic, political, disability, physical, other.
     """
+    planner_metadata = {
+        "description": (
+            "Model-based checker for biased language. "
+            "Uses a ModernBERT multi-label classifier to detect bias categories such as "
+            "racial, gender, religious, political, disability, and socioeconomic bias."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "model_based",
+            "pipeline": [
+                "score each text field except DPO rejected_response",
+                "collect categories whose score meets the configured threshold",
+                "flag when any field has a bias score above threshold",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def __init__(
         self,

--- a/tools/security_audit/checker/model_based/harmful_classifier.py
+++ b/tools/security_audit/checker/model_based/harmful_classifier.py
@@ -37,6 +37,32 @@ class HarmfulContentClassifier(ModelBasedChecker):
     Uses Llama Guard's chat-template-based moderation to classify whether
     a conversation contains harmful content across 14 hazard categories.
     """
+    planner_metadata = {
+        "description": (
+            "Model-based checker for harmful content moderation. "
+            "Uses Llama Guard to classify conversations across MLCommons hazard categories."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "model_based",
+            "pipeline": [
+                "lazy-load the configured Llama Guard model and tokenizer",
+                "convert sample messages and assistant output into chat-template format",
+                "compute unsafe probability and generate hazard category labels",
+                "flag when unsafe probability meets the configured threshold",
+            ],
+        },
+        "cost_profile": {
+            "cost": "high",
+            "latency": "high",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "high",
+            "recall": "high",
+        },
+    }
 
     def __init__(
         self,

--- a/tools/security_audit/checker/model_based/harmful_classifier.py
+++ b/tools/security_audit/checker/model_based/harmful_classifier.py
@@ -82,7 +82,7 @@ class HarmfulContentClassifier(ModelBasedChecker):
         """
         super().__init__()
         self.model_name_or_path = model_name_or_path
-        self.device = device
+        self._device = device
         self.dtype = getattr(torch, dtype, torch.bfloat16)
         self.threshold = threshold
         self.local_files_only = local_files_only
@@ -92,10 +92,14 @@ class HarmfulContentClassifier(ModelBasedChecker):
         self._unsafe_token_id = None
 
     def load_model(self):
+        if self._device == "auto":
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        else:
+            self.device = self._device
         if self.model is not None:
             return
         try:
-            self._log.info("HarmfulContentClassifier: loading Llama Guard model ...")
+            self._log.info(f"HarmfulContentClassifier: loading Llama Guard model on device {self.device} ...")
             self._tokenizer = AutoTokenizer.from_pretrained(
                 self.model_name_or_path,
                 local_files_only=self.local_files_only,

--- a/tools/security_audit/checker/model_based/jailbreak_classifier.py
+++ b/tools/security_audit/checker/model_based/jailbreak_classifier.py
@@ -88,6 +88,32 @@ class JailbreakClassifier(ModelBasedChecker):
       2. Response refusal — whether the assistant refused the request.
       3. Harmful response — whether the assistant's reply itself is harmful.
     """
+    planner_metadata = {
+        "description": (
+            "Model-based checker for jailbreak and harmful request/response behavior. "
+            "Uses WildGuard to judge harmful requests, refusals, and harmful responses."
+        ),
+        "required_fields": ["messages"],
+        "method": {
+            "type": "model_based",
+            "pipeline": [
+                "lazy-load the configured WildGuard causal language model",
+                "extract the last user query and available assistant response",
+                "generate WildGuard safety labels for request harm, refusal, and response harm",
+                "flag harmful request/response combinations according to parsed labels",
+            ],
+        },
+        "cost_profile": {
+            "cost": "high",
+            "latency": "high",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "high",
+            "recall": "medium",
+        },
+    }
 
     def __init__(
         self,

--- a/tools/security_audit/checker/model_based/jailbreak_classifier.py
+++ b/tools/security_audit/checker/model_based/jailbreak_classifier.py
@@ -60,8 +60,13 @@ def _normalize_output(text: str) -> str:
     )
     # ▁ is the SentencePiece word-start marker → space
     text = text.replace("▁", " ")
-    # Remove spaces that were inserted between sub-word letter tokens
-    text = re.sub(r"(?<=[a-zA-Z]) (?=[a-zA-Z])", "", text)
+    # Remove spaces inserted between single-letter subword tokens without
+    # collapsing normal label words such as "Harmful request".
+    text = re.sub(
+        r"\b(?:[A-Za-z] ){2,}[A-Za-z]\b",
+        lambda m: m.group(0).replace(" ", ""),
+        text,
+    )
     # Collapse remaining runs of spaces
     text = re.sub(r" {2,}", " ", text)
     return text.strip()

--- a/tools/security_audit/checker/model_based/pii_ner.py
+++ b/tools/security_audit/checker/model_based/pii_ner.py
@@ -13,6 +13,32 @@ from ...result import CheckResult, RiskType
 class PIINERDetector(ModelBasedChecker):
     """PII detector based on Microsoft Presidio (regex + spaCy NER).
     """
+    planner_metadata = {
+        "description": (
+            "Model-based checker for personally identifiable information (PII). "
+            "Uses Microsoft Presidio and spaCy NER to detect entity-level privacy leaks."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "model_based",
+            "pipeline": [
+                "initialize Presidio analyzer and anonymizer for the configured language",
+                "analyze every text field for supported PII entities",
+                "filter entity detections by confidence threshold",
+                "flag when at least one PII entity is detected and provide redacted evidence",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "high",
+            "recall": "medium",
+        },
+    }
 
     def __init__(
         self,

--- a/tools/security_audit/checker/model_based/prompt_injection_classifier.py
+++ b/tools/security_audit/checker/model_based/prompt_injection_classifier.py
@@ -16,6 +16,32 @@ _INJECTION_LABEL = "injection"
 class PromptInjectionClassifier(ModelBasedChecker):
     """Prompt injection classifier based on PIGuard (DeBERTa v3-base).
     """
+    planner_metadata = {
+        "description": (
+            "Model-based checker for prompt injection attempts. "
+            "Uses PIGuard to classify system and user input as benign or injection."
+        ),
+        "required_fields": ["messages"],
+        "method": {
+            "type": "model_based",
+            "pipeline": [
+                "lazy-load the configured PIGuard sequence classifier",
+                "collect system and user message text as injection source material",
+                "run text classification and extract the injection probability",
+                "flag when the injection score meets the configured threshold",
+            ],
+        },
+        "cost_profile": {
+            "cost": "high",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def __init__(
         self,

--- a/tools/security_audit/checker/model_based/toxicity_classifier.py
+++ b/tools/security_audit/checker/model_based/toxicity_classifier.py
@@ -19,6 +19,33 @@ TOXICITY_LABELS = [
 class ToxicityClassifier(ModelBasedChecker):
     """Toxicity classifier based on the detoxify library (Unitary).
     """
+    planner_metadata = {
+        "description": (
+            "Model-based checker for toxic language. "
+            "Uses Detoxify to score toxicity, severe toxicity, obscenity, threats, "
+            "insults, identity attacks, and sexual explicitness across sample text fields."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "model_based",
+            "pipeline": [
+                "lazy-load the configured Detoxify model variant",
+                "score each text field except DPO rejected_response",
+                "select the highest toxicity label score across fields",
+                "flag when the highest score meets the configured threshold",
+            ],
+        },
+        "cost_profile": {
+            "cost": "medium",
+            "latency": "medium",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "medium",
+        },
+    }
 
     def __init__(
         self,

--- a/tools/security_audit/checker/model_based/toxicity_classifier.py
+++ b/tools/security_audit/checker/model_based/toxicity_classifier.py
@@ -15,6 +15,37 @@ TOXICITY_LABELS = [
 ]
 
 
+class _DetoxifyPredictor:
+    def __init__(self, model, tokenizer, class_names, device):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.class_names = class_names
+        self.device = device
+        self.model.to(self.device)
+
+    def predict(self, text):
+        import torch
+
+        self.model.eval()
+        with torch.no_grad():
+            inputs = self.tokenizer(
+                text, return_tensors="pt", truncation=True, padding=True
+            ).to(self.device)
+            out = self.model(**inputs)[0]
+            scores = torch.sigmoid(out).cpu().detach().numpy()
+
+        results = {}
+        for i, class_name in enumerate(self.class_names):
+            if isinstance(text, str):
+                results[class_name] = scores[0][i]
+            else:
+                results[class_name] = [
+                    scores[example_i][i].tolist()
+                    for example_i in range(len(scores))
+                ]
+        return results
+
+
 @CheckerRegistry.register(RiskType.TOXICITY, tags=["model"])
 class ToxicityClassifier(ModelBasedChecker):
     """Toxicity classifier based on the detoxify library (Unitary).
@@ -52,17 +83,23 @@ class ToxicityClassifier(ModelBasedChecker):
         model_type: str = "unbiased",
         threshold: float = 0.5,
         device: str = "auto",
+        checkpoint: Optional[str] = None,
+        huggingface_config_path: Optional[str] = None,
     ):
         """
         Args:
             model_type: detoxify model variant — "original", "unbiased", or "multilingual".
             threshold: score above which the text is flagged as toxic.
             device: "auto", "cuda", or "cpu".
+            checkpoint: optional local Detoxify checkpoint path for offline loading.
+            huggingface_config_path: optional local HF config/tokenizer directory for offline loading.
         """
         super().__init__()
         self.model_type = model_type
         self.threshold = threshold
         self._device = device
+        self.checkpoint = checkpoint
+        self.huggingface_config_path = huggingface_config_path
         self.model = None
 
     def load_model(self):
@@ -78,7 +115,10 @@ class ToxicityClassifier(ModelBasedChecker):
                 device = self._device
 
             self._log.info(f"ToxicityClassifier: loading detoxify model '{self.model_type}' on {device} ...")
-            self.model = Detoxify(self.model_type, device=device)
+            if self.checkpoint is not None:
+                self.model = self._load_local_detoxify_model(device)
+            else:
+                self.model = Detoxify(self.model_type, device=device)
             self._log.info("ToxicityClassifier: model loaded.")
         except ImportError:
             raise ImportError(
@@ -87,6 +127,48 @@ class ToxicityClassifier(ModelBasedChecker):
             )
         except Exception as e:
             raise RuntimeError(f"ToxicityClassifier: failed to load model '{self.model_type}': {e}") from e
+
+    def _load_local_detoxify_model(self, device: str):
+        import torch
+        import transformers
+
+        loaded = torch.load(self.checkpoint, map_location=device)
+        if "config" not in loaded or "state_dict" not in loaded:
+            raise ValueError(
+                "Detoxify checkpoint needs to contain both config and state_dict"
+            )
+
+        class_names = loaded["config"]["dataset"]["args"]["classes"]
+        rename = {
+            "toxic": "toxicity",
+            "identity_hate": "identity_attack",
+            "severe_toxic": "severe_toxicity",
+        }
+        class_names = [rename.get(class_name, class_name) for class_name in class_names]
+
+        arch_args = loaded["config"]["arch"]["args"]
+        model_class = getattr(transformers, arch_args["model_name"])
+        tokenizer_class = getattr(transformers, arch_args["tokenizer_name"])
+        model_source = self.huggingface_config_path or arch_args["model_type"]
+        local_files_only = self.huggingface_config_path is not None
+
+        config = model_class.config_class.from_pretrained(
+            model_source,
+            num_labels=arch_args["num_classes"],
+            local_files_only=local_files_only,
+        )
+        model = model_class.from_pretrained(
+            pretrained_model_name_or_path=None,
+            config=config,
+            state_dict=loaded["state_dict"],
+            local_files_only=local_files_only,
+        )
+        tokenizer = tokenizer_class.from_pretrained(
+            model_source,
+            local_files_only=local_files_only,
+        )
+
+        return _DetoxifyPredictor(model, tokenizer, class_names, device)
 
     def check(self, sample: DataSample) -> CheckResult:
         base = dict(checker_name=self.name, risk_type=self.risk_type)

--- a/tools/security_audit/checker/rule_based/bias_rule.py
+++ b/tools/security_audit/checker/rule_based/bias_rule.py
@@ -14,6 +14,32 @@ class BiasKeywordRule(RuleBasedChecker):
     Loads bias_hurtlex_en.txt and bias_hurtlex_zh.txt; scans all text fields.
     Score 1.0 on hit, 0.0 otherwise.
     """
+    planner_metadata = {
+        "description": (
+            "Rule-based checker for biased language. "
+            "Scans all text fields against English and Chinese bias keyword wordlists."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "rule_based",
+            "pipeline": [
+                "load bias keyword wordlists",
+                "scan every text field in the sample for keyword hits",
+                "collect field-level keyword evidence",
+                "flag the sample when at least one bias keyword is found",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "low",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "low",
+            "recall": "low",
+        },
+    }
 
     def __init__(self):
         super().__init__()

--- a/tools/security_audit/checker/rule_based/harmful_rule.py
+++ b/tools/security_audit/checker/rule_based/harmful_rule.py
@@ -15,6 +15,32 @@ class HarmfulKeywordRule(RuleBasedChecker):
     Score 1.0 on hit, 0.0 otherwise.
     using field_name + dataset_type.
     """
+    planner_metadata = {
+        "description": (
+            "Rule-based checker for harmful content. "
+            "Scans all text fields against English and Chinese harmful-content keyword wordlists."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "rule_based",
+            "pipeline": [
+                "load harmful-content keyword wordlists",
+                "scan every text field in the sample for keyword hits",
+                "collect field-level keyword evidence",
+                "flag the sample when at least one harmful keyword is found",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "low",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "low",
+            "recall": "low",
+        },
+    }
 
     def __init__(self):
         super().__init__()

--- a/tools/security_audit/checker/rule_based/pii_rule.py
+++ b/tools/security_audit/checker/rule_based/pii_rule.py
@@ -51,6 +51,33 @@ class PIIRule(RuleBasedChecker):
     Credit card numbers are Luhn-validated; CN ID cards use checksum validation.
     Score 1.0 on hit, 0.0 otherwise.
     """
+    planner_metadata = {
+        "description": (
+            "Rule-based checker for personally identifiable information (PII). "
+            "Scans all text fields for known PII regex patterns, including emails, "
+            "phone numbers, credit cards, government IDs, and China-specific identifiers."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "rule_based",
+            "pipeline": [
+                "load PII regex patterns from pii_patterns.json",
+                "scan every text field in the sample for matching patterns",
+                "validate sensitive identifiers with checksum rules when configured",
+                "flag the sample when at least one validated PII match is found",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "low",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "low",
+        },
+    }
 
     def __init__(self):
         super().__init__()

--- a/tools/security_audit/checker/rule_based/secret_rule.py
+++ b/tools/security_audit/checker/rule_based/secret_rule.py
@@ -24,6 +24,33 @@ class SecretRule(RuleBasedChecker):
     Loads patterns from resources/patterns/secret_patterns.json.
     Score 1.0 on hit, 0.0 otherwise.
     """
+    planner_metadata = {
+        "description": (
+            "Rule-based checker for credential and secret leakage. "
+            "Scans all text fields for known token, key, private-key, JWT, "
+            "and generic API credential patterns."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "rule_based",
+            "pipeline": [
+                "load secret regex patterns from secret_patterns.json",
+                "scan every text field in the sample for credential-like matches",
+                "return matched pattern evidence while omitting compiled regex objects",
+                "flag the sample when at least one secret pattern is found",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "low",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "medium",
+            "recall": "low",
+        },
+    }
 
     def __init__(self):
         super().__init__()

--- a/tools/security_audit/checker/rule_based/toxicity_rule.py
+++ b/tools/security_audit/checker/rule_based/toxicity_rule.py
@@ -14,6 +14,32 @@ class ToxicityKeywordRule(RuleBasedChecker):
     Loads toxicity_zh.txt and toxicity_en.txt; scans all text fields.
     Score 1.0 on hit, 0.0 otherwise.
     """
+    planner_metadata = {
+        "description": (
+            "Rule-based checker for toxic language. "
+            "Scans all text fields against English and Chinese toxicity keyword wordlists."
+        ),
+        "required_fields": [],
+        "method": {
+            "type": "rule_based",
+            "pipeline": [
+                "load toxicity keyword wordlists",
+                "scan every text field in the sample for keyword hits",
+                "collect field-level keyword evidence",
+                "flag the sample when at least one toxic keyword is found",
+            ],
+        },
+        "cost_profile": {
+            "cost": "low",
+            "latency": "low",
+            "execution": "per_sample",
+            "requires_llm": False,
+        },
+        "quality_profile": {
+            "precision": "low",
+            "recall": "medium",
+        },
+    }
 
     def __init__(self):
         super().__init__()

--- a/tools/security_audit/config.py
+++ b/tools/security_audit/config.py
@@ -17,7 +17,6 @@ class CheckerConfig(BaseModel):
     name: str
     enabled: bool = True
     params: Dict = {}
-    selection_source: str = "config"  # explicit | config | auto
 
 
 class ExecutorConfig(BaseModel):

--- a/tools/security_audit/config.py
+++ b/tools/security_audit/config.py
@@ -17,6 +17,7 @@ class CheckerConfig(BaseModel):
     name: str
     enabled: bool = True
     params: Dict = {}
+    selection_source: str = "config"  # explicit | config | auto
 
 
 class ExecutorConfig(BaseModel):

--- a/tools/security_audit/default.yaml
+++ b/tools/security_audit/default.yaml
@@ -23,6 +23,10 @@ checkers:
   # - DPOLabelFlipLLMJudge
   # - name: JailbreakLLMJudge
   #   enabled: false
+  - name: PIINERDetector
+    enabled: false
+    params:
+      language: en
   - name: JailbreakClassifier
     enabled: false
     params:

--- a/tools/security_audit/default.yaml
+++ b/tools/security_audit/default.yaml
@@ -35,7 +35,13 @@ checkers:
   - name: PromptInjectionClassifier
     enabled: false
     params:
-      model_name_or_path: leolee99/PIGuard
+      model_name_or_path: /mnt/shared-storage-user/chenbei/.data/leolee99/PIGuard
+  - name: ToxicityClassifier
+    enabled: false
+    params:
+      model_type: unbiased
+      checkpoint: /mnt/shared-storage-user/chenbei/.data/detoxify/toxic_debiased-c7548aa0.ckpt
+      huggingface_config_path: /mnt/shared-storage-user/chenbei/.data/detoxify/models--roberta-base/snapshots/e2da8e2f811d1448a5b465c236feacd80ffbac7b
   - name: HarmfulContentClassifier
     enabled: false
     params:
@@ -43,7 +49,7 @@ checkers:
   - name: BiasClassifier
     enabled: false
     params:
-      model_name_or_path: cirimus/modernbert-large-bias-type-classifier
+      model_name_or_path: /mnt/shared-storage-user/chenbei/.data/cirimus/modernbert-large-bias-type-classifier
   - name: GraCeFulBackdoorDefender
     enabled: false
     params:

--- a/tools/security_audit/default.yaml
+++ b/tools/security_audit/default.yaml
@@ -2,7 +2,8 @@
 # Loaded automatically when required_security_audit_tool: true in upper config.
 # Users can override individual values via tool_defaults.security_audit in their config.
 
-# Checkers to enable. Priority: call-time checker_names arg > this list.
+# Checkers to enable for checker_selection_mode=default. Legacy call-time
+# checker_names still implies checker_selection_mode=explicit.
 # Each entry can be a plain string (checker class name) or a dict with name/enabled/params.
 # Available checkers:
 #   Rule-based:  PIIRule, SecretRule, ToxicityKeywordRule, HarmfulKeywordRule,
@@ -67,4 +68,3 @@ risk_weights:
   prompt_injection: 10
   jailbreak: 10
   sycophancy: 2
-

--- a/tools/security_audit/executor.py
+++ b/tools/security_audit/executor.py
@@ -301,7 +301,10 @@ class Executor:
                     risk_type=checker.risk_type,
                     details={"error": str(e)},
                 )
-            sr.results.append(result)
+            if isinstance(result, list):
+                sr.results.extend(result)
+            else:
+                sr.results.append(result)
         return sr
 
     def _aggregate(self, report: TaskReport, sample_reports: List[SampleReport]) -> None:

--- a/tools/security_audit/policy.py
+++ b/tools/security_audit/policy.py
@@ -67,7 +67,6 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
             "HarmfulKeywordRule",
             "ToxicityKeywordRule",
             "BiasKeywordRule",
-            "PIILLMJudge",
             "PIINERDetector",
         ],
         "routing": {"mode": "all_samples"},
@@ -90,6 +89,7 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
             "sycophancy",
         ],
         "checkers": [
+            "PIILLMJudge",
             "HarmfulContentLLMJudge",
             "ToxicityLLMJudge",
             "BiasLLMJudge",
@@ -758,19 +758,14 @@ def _resolve_llm_checker_plan(
     data_profile: dict[str, Any] | None,
 ) -> ResolvedCheckerPlan:
     if llm is None or not llm_model:
-        plan = _resolve_default_llm_progressive_workflow_plan(
+        return _resolve_deterministic_single_stage_plan(
             request=request,
             capability_set=capability_set,
             defaults_by_name=defaults_by_name,
+            resource_tier=resource_tier,
             source=source,
+            reason="llm_resolver_unavailable",
         )
-        plan.strategy = "deterministic"
-        plan.degradations.append({
-            "reason": "llm_resolver_unavailable" if llm is None else "llm_model_unavailable",
-            "from": "llm",
-            "to": "deterministic_progressive_workflow",
-        })
-        return plan
 
     prompt = build_llm_resolver_prompt(
         request=request,
@@ -803,45 +798,52 @@ def _resolve_llm_checker_plan(
         )
     except Exception as exc:
         if logger is not None and hasattr(logger, "warning"):
-            logger.warning(f"SecurityAuditTool: LLM resolver failed, falling back to deterministic progressive workflow: {exc}")
-        plan = _resolve_default_llm_progressive_workflow_plan(
+            logger.warning(f"SecurityAuditTool: LLM resolver failed, falling back to deterministic single-stage plan: {exc}")
+        return _resolve_deterministic_single_stage_plan(
             request=request,
             capability_set=capability_set,
             defaults_by_name=defaults_by_name,
+            resource_tier=resource_tier,
             source=source,
+            reason="llm_resolver_failed",
         )
-        plan.strategy = "deterministic"
-        plan.degradations.append({
-            "reason": "llm_resolver_failed",
-            "from": "llm",
-            "to": "deterministic",
-        })
-        return plan
 
 
-def _resolve_default_llm_progressive_workflow_plan(
+def _resolve_deterministic_single_stage_plan(
     *,
     request: CheckerRequest,
     capability_set: CheckerCapabilitySet,
     defaults_by_name: dict[str, CheckerConfig],
+    resource_tier: str,
     source: str,
+    reason: str,
 ) -> ResolvedCheckerPlan:
-    stages, names, skipped, degradations = build_progressive_workflow_stages(capability_set)
-    checker_configs, config_skipped = _checker_configs_from_names(
+    names, degradations = _recommend_checker_names(
+        request=request,
+        capability_set=capability_set,
+        default_configs=list(defaults_by_name.values()),
+        resource_tier=resource_tier,
+    )
+    checker_configs, skipped = _checker_configs_from_names(
         names=names,
         defaults_by_name=defaults_by_name,
         capability_set=capability_set,
     )
-    return ResolvedCheckerPlan(
-        strategy="llm",
-        checker_configs=checker_configs,
-        skipped_checkers=_dedupe_skip_records(skipped + config_skipped),
-        degradations=degradations,
-        source=source,
-        objective=_default_progressive_workflow_objective(stages),
-        stages=stages,
+    return _resolved_plan(
         request=request,
         capability_set=capability_set,
+        strategy="deterministic",
+        checker_configs=checker_configs,
+        skipped_checkers=skipped,
+        degradations=[
+            {
+                "reason": reason,
+                "from": "llm",
+                "to": "deterministic_single_stage",
+            },
+            *degradations,
+        ],
+        source=source,
     )
 
 

--- a/tools/security_audit/policy.py
+++ b/tools/security_audit/policy.py
@@ -7,9 +7,12 @@ from typing import Any
 
 from config import PreflightIssue, RuntimePolicy
 
+from .checker.base import CheckerType
 from .checker.registry import CheckerRegistry
 from .config import CheckerConfig
 
+
+_SELECTION_MODES = {"explicit", "recommend", "default"}
 
 _RULE_BASED_CHECKERS = [
     "PIIRule",
@@ -82,25 +85,23 @@ _WEIGHT_SUFFIXES = (".safetensors", ".bin")
 
 @dataclass(frozen=True)
 class CheckerRequest:
-    raw_checker_names: Any = None
-    has_checker_names: bool = False
+    selection_mode: str = "default"
+    checker_names: list[str] = field(default_factory=list)
+    checker_preferences: str = ""
     strategy: str = "single_stage"
+    raw: dict[str, Any] = field(default_factory=dict)
 
     @property
     def explicit(self) -> bool:
-        return self.has_checker_names
-
-    @property
-    def checker_names(self) -> list[str]:
-        if isinstance(self.raw_checker_names, list):
-            return [name for name in self.raw_checker_names if isinstance(name, str)]
-        return []
+        return self.selection_mode == "explicit"
 
 
 @dataclass
 class CheckerCapability:
     name: str
     allowed: bool
+    checker_type: str | None = None
+    risk_type: str | None = None
     required_tier: str | None = None
     params: dict[str, Any] = field(default_factory=dict)
     issues: list[PreflightIssue] = field(default_factory=list)
@@ -123,24 +124,77 @@ class CheckerCapabilitySet:
         capability = self.get(checker_name)
         return bool(capability and capability.allowed)
 
+    def allowed_names(self) -> list[str]:
+        return sorted(name for name, capability in self.capabilities.items() if capability.allowed)
+
+    def blocked(self) -> list[CheckerCapability]:
+        return sorted(
+            [capability for capability in self.capabilities.values() if not capability.allowed],
+            key=lambda capability: capability.name,
+        )
+
+    def blocked_metadata(self) -> list[dict[str, Any]]:
+        blocked = []
+        for capability in self.blocked():
+            blocked.append({
+                "name": capability.name,
+                "reasons": [issue.code for issue in capability.issues] or ["checker_not_allowed"],
+            })
+        return blocked
+
 
 @dataclass
 class ResolvedCheckerPlan:
     strategy: str
+    source: str
     checker_configs: list[CheckerConfig]
     skipped_checkers: list[dict[str, str]] = field(default_factory=list)
-    source: str = "auto"
+    degradations: list[dict[str, str]] = field(default_factory=list)
+    stages: list[dict[str, Any]] = field(default_factory=list)
+    request: CheckerRequest | None = None
+    capability_set: CheckerCapabilitySet | None = None
 
 
 def build_checker_request(kwargs: dict, tool_defaults: dict) -> CheckerRequest:
     # TODO: (resource_tier) Let security_audit strategies accept explicit
     # strategy names once funnel policies are implemented.
     strategy = str(kwargs.get("strategy") or tool_defaults.get("strategy") or "single_stage")
+    raw = dict(kwargs)
+    raw_checker_names = kwargs.get("checker_names")
+    has_checker_names = "checker_names" in kwargs
+    raw_mode = kwargs.get("checker_selection_mode")
+    selection_mode = str(raw_mode or "").strip().lower()
+
+    if not selection_mode:
+        selection_mode = "explicit" if has_checker_names else "default"
+
+    checker_names = raw_checker_names if isinstance(raw_checker_names, list) else []
+    raw_checker_preferences = kwargs.get("checker_preferences")
+    checker_preferences = raw_checker_preferences if isinstance(raw_checker_preferences, str) else ""
+    if selection_mode == "default":
+        checker_preferences = ""
+
     return CheckerRequest(
-        raw_checker_names=kwargs.get("checker_names"),
-        has_checker_names="checker_names" in kwargs,
+        selection_mode=selection_mode,
+        checker_names=_unique_checker_names(checker_names),
+        checker_preferences=checker_preferences,
         strategy=strategy,
+        raw=raw,
     )
+
+
+def _unique_checker_names(raw_names: list[Any]) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for raw_name in raw_names:
+        if not isinstance(raw_name, str):
+            continue
+        name = raw_name.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
 
 
 def validate_checker_request(
@@ -149,6 +203,16 @@ def validate_checker_request(
     context_config: dict[str, Any],
 ) -> list[PreflightIssue]:
     issues: list[PreflightIssue] = []
+    if request.selection_mode not in _SELECTION_MODES:
+        issues.append(PreflightIssue(
+            level="error",
+            code="invalid_checker_selection_mode",
+            message=(
+                "checker_selection_mode must be one of "
+                f"{sorted(_SELECTION_MODES)}, got {request.selection_mode!r}."
+            ),
+        ))
+
     if not isinstance(request.strategy, str) or not request.strategy.strip():
         issues.append(PreflightIssue(
             level="error",
@@ -156,25 +220,39 @@ def validate_checker_request(
             message="security_audit strategy must be a non-empty string.",
         ))
 
-    if not request.has_checker_names:
-        return issues
+    raw_checker_names = request.raw.get("checker_names")
+    has_checker_names = "checker_names" in request.raw
 
-    if not isinstance(request.raw_checker_names, list):
-        return issues + [PreflightIssue(
+    if has_checker_names and not isinstance(raw_checker_names, list):
+        issues.append(PreflightIssue(
             level="error",
             code="invalid_checker_names",
             message="checker_names must be a list of checker class names.",
-        )]
+        ))
 
-    if not request.raw_checker_names:
+    if (
+        request.selection_mode != "default"
+        and "checker_preferences" in request.raw
+        and not isinstance(request.raw.get("checker_preferences"), str)
+    ):
+        issues.append(PreflightIssue(
+            level="error",
+            code="invalid_checker_preferences",
+            message="checker_preferences must be a string.",
+        ))
+
+    if request.selection_mode != "explicit":
+        return issues
+
+    if not request.checker_names:
         return issues + [PreflightIssue(
             level="error",
             code="empty_checker_names",
-            message="checker_names cannot be empty when explicitly provided.",
+            message="explicit checker selection requires a non-empty checker_names list.",
         )]
 
     available = _available_checker_names()
-    for raw_name in request.raw_checker_names:
+    for raw_name in raw_checker_names if isinstance(raw_checker_names, list) else []:
         if not isinstance(raw_name, str) or not raw_name.strip():
             issues.append(PreflightIssue(
                 level="error",
@@ -221,7 +299,6 @@ def build_checker_capability_set(
                 checker_config=CheckerConfig(
                     name=name,
                     params=dict(params_by_name.get(name, {})),
-                    selection_source="capability",
                 ),
                 runtime_policy=runtime_policy,
                 context_config=context_config,
@@ -229,6 +306,8 @@ def build_checker_capability_set(
 
         capabilities[name] = CheckerCapability(
             name=name,
+            checker_type=_checker_type(name),
+            risk_type=_risk_type(name),
             allowed=not any(issue.level == "error" for issue in issues),
             required_tier=_CHECKER_MIN_RESOURCE_TIERS.get(name),
             params=dict(params_by_name.get(name, {})),
@@ -247,20 +326,41 @@ def resolve_checker_plan(
     default_configs = load_default_checker_configs(tool_defaults)
     defaults_by_name = {config.name: config for config in default_configs}
 
-    if request.explicit:
-        checker_configs = []
-        for name in request.checker_names:
-            default_config = defaults_by_name.get(name)
-            checker_configs.append(CheckerConfig(
-                name=name,
-                enabled=True,
-                params=dict(default_config.params) if default_config else {},
-                selection_source="explicit",
-            ))
-        return ResolvedCheckerPlan(
-            strategy=request.strategy,
+    if request.selection_mode == "explicit":
+        checker_configs, skipped = _checker_configs_from_names(
+            names=request.checker_names,
+            defaults_by_name=defaults_by_name,
+            capability_set=capability_set,
+        )
+        return _resolved_plan(
+            request=request,
+            capability_set=capability_set,
+            strategy="deterministic",
             checker_configs=checker_configs,
+            skipped_checkers=skipped,
             source="explicit",
+        )
+
+    if request.selection_mode == "recommend":
+        names, degradations = _recommend_checker_names(
+            request=request,
+            capability_set=capability_set,
+            default_configs=default_configs,
+            resource_tier=resource_tier,
+        )
+        checker_configs, skipped = _checker_configs_from_names(
+            names=names,
+            defaults_by_name=defaults_by_name,
+            capability_set=capability_set,
+        )
+        return _resolved_plan(
+            request=request,
+            capability_set=capability_set,
+            strategy="deterministic",
+            checker_configs=checker_configs,
+            skipped_checkers=skipped,
+            degradations=degradations,
+            source="recommend",
         )
 
     if default_configs:
@@ -277,29 +377,33 @@ def resolve_checker_plan(
                 "name": config.name,
                 "reason": capability.blocked_reason if capability else "unknown_checker",
             })
-        return ResolvedCheckerPlan(
-            strategy=request.strategy,
+        return _resolved_plan(
+            request=request,
+            capability_set=capability_set,
+            strategy="deterministic",
             checker_configs=checker_configs,
             skipped_checkers=skipped,
-            source="config",
+            source="default",
         )
 
     checker_configs = []
     skipped = []
     for name in resolve_default_checkers_for_resource_tier(resource_tier):
         if capability_set.is_allowed(name):
-            checker_configs.append(CheckerConfig(name=name, selection_source="auto"))
+            checker_configs.append(CheckerConfig(name=name))
         else:
             capability = capability_set.get(name)
             skipped.append({
                 "name": name,
                 "reason": capability.blocked_reason if capability else "unknown_checker",
             })
-    return ResolvedCheckerPlan(
-        strategy=request.strategy,
+    return _resolved_plan(
+        request=request,
+        capability_set=capability_set,
+        strategy="deterministic",
         checker_configs=checker_configs,
         skipped_checkers=skipped,
-        source="auto",
+        source="fallback",
     )
 
 
@@ -319,6 +423,64 @@ def validate_resolved_checker_plan(
             message="security_audit resolved plan has no enabled checkers.",
         ))
         return issues
+
+    enabled_names = {config.name for config in enabled_configs}
+    stage_names: set[str] = set()
+    for stage in plan.stages:
+        stage_checkers = stage.get("checkers", [])
+        if not isinstance(stage_checkers, list):
+            issues.append(PreflightIssue(
+                level="error",
+                code="invalid_stage_checkers",
+                message=f"Resolved stage `{stage.get('id', '')}` checkers must be a list.",
+            ))
+            continue
+
+        for checker_name in stage_checkers:
+            if not isinstance(checker_name, str) or not checker_name.strip():
+                issues.append(PreflightIssue(
+                    level="error",
+                    code="invalid_stage_checker_name",
+                    message=(
+                        f"Resolved stage `{stage.get('id', '')}` checker names must be "
+                        f"non-empty strings, got {checker_name!r}."
+                    ),
+                ))
+                continue
+
+            normalized_name = checker_name.strip()
+            stage_names.add(normalized_name)
+            if not capability_set.is_allowed(normalized_name):
+                issues.append(PreflightIssue(
+                    level="error",
+                    code="stage_checker_not_allowed",
+                    checker_name=normalized_name,
+                    message=(
+                        f"Resolved stage `{stage.get('id', '')}` contains checker "
+                        f"`{checker_name}` outside the current capability set."
+                    ),
+                ))
+            if normalized_name not in enabled_names:
+                issues.append(PreflightIssue(
+                    level="error",
+                    code="stage_checker_not_enabled",
+                    checker_name=normalized_name,
+                    message=(
+                        f"Resolved stage `{stage.get('id', '')}` contains checker "
+                        f"`{checker_name}` that is not enabled in checker_configs."
+                    ),
+                ))
+
+    for checker_config in enabled_configs:
+        if checker_config.name not in stage_names:
+            issues.append(PreflightIssue(
+                level="error",
+                code="enabled_checker_missing_from_stages",
+                checker_name=checker_config.name,
+                message=(
+                    f"Enabled checker `{checker_config.name}` is missing from resolved plan stages."
+                ),
+            ))
 
     available = _available_checker_names()
     for checker_config in enabled_configs:
@@ -359,6 +521,143 @@ def validate_resolved_checker_plan(
     return issues
 
 
+def checker_request_metadata(request: CheckerRequest) -> dict[str, Any]:
+    return {
+        "checker_selection_mode": request.selection_mode,
+        "checker_names": list(request.checker_names),
+        "checker_preferences": request.checker_preferences,
+    }
+
+
+def capability_set_metadata(capability_set: CheckerCapabilitySet) -> dict[str, Any]:
+    return {
+        "allowed_checker_names": capability_set.allowed_names(),
+        "blocked_checkers": capability_set.blocked_metadata(),
+    }
+
+
+def resolved_plan_metadata(plan: ResolvedCheckerPlan) -> dict[str, Any]:
+    return {
+        "schema_version": "security_audit.resolved_plan.v1",
+        "strategy": plan.strategy,
+        "source": plan.source,
+        "stages": list(plan.stages),
+        "skipped_checkers": list(plan.skipped_checkers),
+        "degradations": list(plan.degradations),
+    }
+
+
+def _resolved_plan(
+    *,
+    request: CheckerRequest,
+    capability_set: CheckerCapabilitySet,
+    strategy: str,
+    checker_configs: list[CheckerConfig],
+    skipped_checkers: list[dict[str, str]] | None = None,
+    degradations: list[dict[str, str]] | None = None,
+    source: str,
+) -> ResolvedCheckerPlan:
+    enabled_names = [config.name for config in checker_configs if config.enabled]
+    return ResolvedCheckerPlan(
+        strategy=strategy,
+        checker_configs=checker_configs,
+        skipped_checkers=skipped_checkers or [],
+        degradations=degradations or [],
+        source=source,
+        stages=[_single_stage(enabled_names)],
+        request=request,
+        capability_set=capability_set,
+    )
+
+
+def _single_stage(checker_names: list[str]) -> dict[str, Any]:
+    return {
+        "id": "stage_1",
+        "name": "single_stage",
+        "type": "single_stage",
+        "checkers": list(checker_names),
+        "input_scope": {
+            "type": "all_samples",
+            "source_stage_id": None,
+        },
+        "routing": {
+            "mode": "all",
+        },
+    }
+
+
+def _checker_configs_from_names(
+    *,
+    names: list[str],
+    defaults_by_name: dict[str, CheckerConfig],
+    capability_set: CheckerCapabilitySet,
+) -> tuple[list[CheckerConfig], list[dict[str, str]]]:
+    checker_configs: list[CheckerConfig] = []
+    skipped: list[dict[str, str]] = []
+
+    for name in names:
+        if not capability_set.is_allowed(name):
+            capability = capability_set.get(name)
+            skipped.append({
+                "name": name,
+                "reason": capability.blocked_reason if capability else "unknown_checker",
+            })
+            continue
+
+        default_config = defaults_by_name.get(name)
+        checker_configs.append(CheckerConfig(
+            name=name,
+            enabled=True,
+            params=dict(default_config.params) if default_config else {},
+        ))
+    return checker_configs, skipped
+
+
+def _recommend_checker_names(
+    *,
+    request: CheckerRequest,
+    capability_set: CheckerCapabilitySet,
+    default_configs: list[CheckerConfig],
+    resource_tier: str,
+) -> tuple[list[str], list[dict[str, str]]]:
+    allowed = set(capability_set.allowed_names())
+    preference = request.checker_preferences.lower()
+
+    fast_markers = ("fast", "quick", "low cost", "low-cost", "cheap", "light", "成本", "快速", "低成本")
+    broad_markers = ("accurate", "accuracy", "coverage", "strong", "full", "全面", "准确", "覆盖")
+
+    if any(marker in preference for marker in fast_markers):
+        names = [name for name in _RULE_BASED_CHECKERS if name in allowed]
+        if names:
+            return names, []
+
+    if any(marker in preference for marker in broad_markers):
+        names = [
+            name for name in _coverage_checker_names_for_resource_tier(resource_tier)
+            if name in allowed
+        ]
+        if names:
+            return names, []
+
+    configured = [config.name for config in default_configs if config.enabled and config.name in allowed]
+    if configured:
+        return configured, [{
+            "reason": "recommendation_fell_back_to_default_config",
+            "from": "recommend",
+            "to": "default",
+        }]
+
+    fallback = [
+        name for name in resolve_default_checkers_for_resource_tier(resource_tier)
+        if name in allowed
+    ]
+    return fallback, [{
+        "reason": "recommendation_fell_back_to_resource_tier_defaults",
+        "from": "recommend",
+        "to": "fallback",
+    }]
+
+
 def load_default_checker_configs(tool_defaults: dict) -> list[CheckerConfig]:
     raw = tool_defaults.get("checkers")
     if not isinstance(raw, list):
@@ -367,14 +666,33 @@ def load_default_checker_configs(tool_defaults: dict) -> list[CheckerConfig]:
     configs: list[CheckerConfig] = []
     for item in raw:
         if isinstance(item, str):
-            configs.append(CheckerConfig(name=item, selection_source="config"))
+            configs.append(CheckerConfig(name=item))
         elif isinstance(item, dict) and "name" in item:
-            configs.append(CheckerConfig(**{**item, "selection_source": "config"}))
+            configs.append(CheckerConfig(**item))
     return configs
 
 
 def _available_checker_names() -> set[str]:
     return set(CheckerRegistry.list_all())
+
+
+def _checker_type(checker_name: str) -> str | None:
+    try:
+        checker_type = getattr(CheckerRegistry.get(checker_name), "checker_type", None)
+    except KeyError:
+        return None
+    if isinstance(checker_type, CheckerType):
+        return checker_type.value
+    return str(checker_type) if checker_type else None
+
+
+def _risk_type(checker_name: str) -> str | None:
+    try:
+        risk_type = getattr(CheckerRegistry.get(checker_name), "risk_type", None)
+    except KeyError:
+        return None
+    value = getattr(risk_type, "value", None)
+    return str(value or risk_type) if risk_type else None
 
 
 def _validate_checker_resource_tier(
@@ -422,16 +740,28 @@ def resolve_default_checkers_for_resource_tier(resource_tier: str) -> list[str]:
     normalized = (resource_tier or "light").strip().lower()
     if normalized == "standard":
         return [
+            *_RULE_BASED_CHECKERS,
             *_STANDARD_MODEL_CHECKERS,
             *_LLM_JUDGE_CHECKERS,
         ]
     if normalized == "full":
         return [
+            *_RULE_BASED_CHECKERS,
             *_STANDARD_MODEL_CHECKERS,
             *_LLM_JUDGE_CHECKERS,
             *_HEAVY_MODEL_CHECKERS,
         ]
     return list(_RULE_BASED_CHECKERS)
+
+
+def _coverage_checker_names_for_resource_tier(resource_tier: str) -> list[str]:
+    names = resolve_default_checkers_for_resource_tier(resource_tier)
+    if (resource_tier or "").strip().lower() == "full":
+        available = _available_checker_names()
+        for name in sorted(available):
+            if name not in names:
+                names.append(name)
+    return names
 
 
 def validate_checker_network_availability(

--- a/tools/security_audit/policy.py
+++ b/tools/security_audit/policy.py
@@ -141,7 +141,6 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
         "checkers": ["InstructionMismatchLLMJudge"],
         "routing": {
             "mode": "field_applicable",
-            "required_fields": ["response"],
         },
         "purpose": "Audit whether responses follow instructions only when both instructions/messages and a response are present.",
     },
@@ -153,7 +152,6 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
         "checkers": ["SelfContradictionLLMJudge"],
         "routing": {
             "mode": "field_applicable",
-            "required_fields": ["response"],
         },
         "purpose": "Audit internal response contradictions only on samples that contain a model response or assistant message.",
     },
@@ -165,7 +163,6 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
         "checkers": ["SycophancyLLMJudge"],
         "routing": {
             "mode": "field_applicable",
-            "required_fields": ["response"],
         },
         "purpose": "Audit sycophancy only when user messages and a model response are available.",
     },
@@ -178,7 +175,6 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
         "routing": {
             "mode": "field_applicable",
             "dataset_types": ["dpo"],
-            "required_fields": ["chosen_response", "rejected_response"],
         },
         "purpose": "Audit DPO preference pairs independently from general semantic stages because the checker requires chosen and rejected responses.",
     },
@@ -190,7 +186,6 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
         "checkers": ["FactualInconsistancyLLMJudge"],
         "routing": {
             "mode": "field_applicable",
-            "required_fields": ["context"],
         },
         "purpose": "Audit factual consistency only when trusted context and a response are present.",
     },
@@ -249,16 +244,15 @@ LLM_RESOLVER_OUTPUT_SCHEMA: dict[str, Any] = {
             "type": "quick_scan|semantic_scan|deep_scan",
             "risk_focus": ["risk_type_name"],
             "checkers": ["CheckerClassName"],
-            "routing": {
-                "mode": "all_samples|field_applicable|uncertain|sample",
-                "source_stage_id": "string|null",
-                "rules": ["near_threshold|conflicting|low_confidence|error|content_filter|unflagged"],
-                "dataset_types": ["sft|rl|dpo|benchmark"],
-                "required_fields": ["messages|response|chosen_response|rejected_response|context|ground_truth_answer|reference_answer"],
-                "sample_rate": "optional number",
-                "sample_size": "optional number",
-                "threshold": "optional number",
-                "threshold_margin": "optional number",
+        "routing": {
+            "mode": "all_samples|field_applicable|uncertain|sample",
+            "source_stage_id": "string|null",
+            "rules": ["near_threshold|conflicting|low_confidence|error|content_filter|unflagged"],
+            "dataset_types": ["sft|rl|dpo|benchmark"],
+            "sample_rate": "optional number",
+            "sample_size": "optional number",
+            "threshold": "optional number",
+            "threshold_margin": "optional number",
             },
             "purpose": "string",
         }
@@ -279,16 +273,16 @@ Hard constraints:
 - Build funnel-style plans only when they match the user intent. For fast or low-cost audits, cheap rule-based checks can run first. For high-precision and high-recall audits, skip low-precision/low-recall rule-based quick_scan stages and start from stronger LLM judges or model/guard checkers. Later stages should use stronger or more specialized checkers, not repeat earlier checkers.
 - A stage should group checkers that share similar cost, data applicability, and routing. Split checkers into separate stages when they need different dataset types, required fields, upstream source stages, sampling, or review rules.
 - Treat the Progressive Risk Audit Workflow as a menu of reusable stage patterns, not a required sequence. You may remove, reorder, merge, or split patterns as long as dependencies are valid. In particular, quick_scan is optional and should be omitted when it does not improve the requested precision/recall objective.
-- Field-specific checks should usually be independent stages with explicit routing, but required_fields may only contain real DataSample fields. Examples: DPOLabelFlipLLMJudge uses dataset_types=["dpo"] and required_fields=["chosen_response", "rejected_response"]; FactualInconsistancyLLMJudge uses required_fields=["context"]; InstructionMismatchLLMJudge and SycophancyLLMJudge use required_fields=["response"]. Do not output virtual field names.
+- Field-specific checks should usually be independent stages with explicit routing. For routing.mode="field_applicable", the local resolver reads each selected checker's required_fields from its checker card and filters samples per checker; do not output routing.required_fields or infer field names yourself.
 - For partial-risk requests, remove irrelevant stages or checkers from the workflow.
 - If a requested target cannot be satisfied by the allowed capability set, omit unavailable checkers from stages; the local resolver will derive skipped_checkers and degradations deterministically.
 - Prefer low-cost routing, sampling, and rule-based checkers only when the user asks for fast, low-cost, preview, or very large-scale audits. Do not include rule-based checkers by default for high-precision high-recall audits unless they are explicitly requested or provide unique coverage such as secrets.
 
 Routing guidance:
-- routing may only contain these keys: mode, source_stage_id, rules, dataset_types, required_fields, sample_rate, sample_size, threshold, threshold_margin.
+- routing may only contain these keys: mode, source_stage_id, rules, dataset_types, sample_rate, sample_size, threshold, threshold_margin.
 - Do not put risk_types or checker_names inside routing; use stage.risk_focus and stage.checkers instead.
 - Use mode=all_samples only for checks that should run over every sample. Rule-based all-sample quick scans are mainly for fast/low-cost pre-screening, not mandatory for high-precision high-recall plans.
-- Use mode=field_applicable for checks that require specific real DataSample fields or dataset types; add required_fields and dataset_types when known.
+- Use mode=field_applicable for checks that require specific real DataSample fields or dataset types; add dataset_types when known, but leave field requirements to the local checker-card logic.
 - Use mode=sample for low-cost previews over applicable samples, or for expensive specialist checks when cost control is requested; set sample_rate or sample_size only with mode=sample.
 - Use mode=uncertain only for a later review/recall stage with unused stronger/specialized checker(s) for the same risk type as the source stage. For high-precision review, use rules such as ["near_threshold", "conflicting", "low_confidence"], usually with threshold=0.5 and threshold_margin=0.1. For high-recall second-pass scanning, use rules=["unflagged"] to route samples not flagged by the source stage to a stronger checker. If all suitable checkers for that risk type have already been used or are unavailable, omit the uncertain review stage.
 - source_stage_id must reference an earlier stage id in your output.
@@ -1460,7 +1454,17 @@ def _checker_card_for_prompt(capability: CheckerCapability) -> dict[str, Any]:
         "risk_type": capability.risk_type,
         "required_tier": capability.required_tier,
         "params": capability.params,
+        **_checker_planner_metadata(capability.name),
     }
+
+
+def _checker_planner_metadata(checker_name: str) -> dict[str, Any]:
+    try:
+        checker_cls = CheckerRegistry.get(checker_name)
+    except KeyError:
+        return {}
+    metadata = getattr(checker_cls, "planner_metadata", None)
+    return dict(metadata) if isinstance(metadata, dict) else {}
 
 
 def _checker_configs_from_names(

--- a/tools/security_audit/policy.py
+++ b/tools/security_audit/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -46,12 +47,152 @@ _HEAVY_MODEL_CHECKERS = [
     "BiasClassifier",
     "JailbreakClassifier",
     "PromptInjectionClassifier",
+    "CrossModelRiskReviewer",
     "GraCeFulBackdoorDefender",
 ]
 
-_HEAVY_CHECKERS = set(_HEAVY_MODEL_CHECKERS)
-
 _RESOURCE_TIER_ORDER = {"light": 0, "standard": 1, "full": 2}
+
+_RESOLVE_STRATEGIES = {"deterministic", "llm"}
+
+_PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
+    {
+        "id": "stage_1",
+        "name": "quick_scan",
+        "type": "quick_scan",
+        "risk_focus": ["pii", "secret", "harmful", "toxicity", "bias"],
+        "checkers": [
+            "PIIRule",
+            "SecretRule",
+            "HarmfulKeywordRule",
+            "ToxicityKeywordRule",
+            "BiasKeywordRule",
+            "PIILLMJudge",
+            "PIINERDetector",
+        ],
+        "routing": {"mode": "all_samples"},
+        "purpose": "Run cheap full-scan checks for direct leakage and obvious surface risks before semantic review.",
+    },
+    {
+        "id": "stage_2",
+        "name": "semantic_scan",
+        "type": "semantic_scan",
+        "risk_focus": [
+            "harmful",
+            "toxicity",
+            "bias",
+            "prompt_injection",
+            "jailbreak",
+            "instruction_mismatch",
+            "label_flipping",
+            "factual_inconsistency",
+            "self_contradiction",
+            "sycophancy",
+        ],
+        "checkers": [
+            "HarmfulContentLLMJudge",
+            "ToxicityLLMJudge",
+            "BiasLLMJudge",
+            "PromptInjectionLLMJudge",
+            "JailbreakLLMJudge",
+            "InstructionMismatchLLMJudge",
+            "DPOLabelFlipLLMJudge",
+            "FactualInconsistancyLLMJudge",
+            "SelfContradictionLLMJudge",
+            "SycophancyLLMJudge",
+        ],
+        "routing": {
+            "mode": "field_applicable",
+        },
+        "purpose": "Find semantic safety, poisoning, alignment bypass, and dataset-label risks.",
+    },
+    {
+        "id": "stage_3",
+        "name": "deep_scan",
+        "type": "deep_scan",
+        "risk_focus": [
+            "backdoor",
+            "harmful",
+            "toxicity",
+            "bias",
+            "jailbreak",
+            "prompt_injection",
+        ],
+        "checkers": [
+            "GraCeFulBackdoorDefender",
+            "HarmfulContentClassifier",
+            "ToxicityClassifier",
+            "BiasClassifier",
+            "JailbreakClassifier",
+            "PromptInjectionClassifier",
+        ],
+        "routing": {
+            "mode": "high_risk_partition",
+            "source_stage_id": "stage_2",
+        },
+        "purpose": "Run higher-cost specialist model checks when resources allow it, prioritizing sampled data, high-risk partitions, and upstream flagged samples.",
+    },
+    # TODO: Add a fourth review stage with CrossModelRiskReviewer for high-risk, low-confidence, near-threshold, or conflicting findings from earlier stages.
+    # {
+    #     "id": "stage_4",
+    #     "name": "review",
+    #     "type": "review",
+    #     "risk_focus": ["cross_model_review", "uncertainty_review"],
+    #     "checkers": ["CrossModelRiskReviewer"],
+    #     "routing": {
+    #         "mode": "uncertain",
+    #         "source_stage_id": "stage_3",
+    #     },
+    #     "purpose": "Conditionally review high-risk, low-confidence, near-threshold, or conflicting findings with CrossModelRiskReviewer.",
+    # },
+]
+
+LLM_RESOLVER_OUTPUT_SCHEMA: dict[str, Any] = {
+    "objective": {
+        "goal": "string",
+        "covered_risk_types": ["string"],
+        "optimization": ["low_cost|fast|high_recall|high_precision|coverage|compliance"],
+    },
+    "stages": [
+        {
+            "id": "stage_number",
+            "name": "string",
+            "type": "quick_scan|semantic_scan|deep_scan|review",
+            "checkers": ["CheckerClassName"],
+            "routing": {
+                "mode": "all_samples|field_applicable|uncertain|sample|high_risk_partition",
+                "source_stage_id": "string|null",
+                "rules": ["string"],
+            },
+            "purpose": "string",
+        }
+    ],
+}
+
+LLM_RESOLVER_PROMPT_TEMPLATE = """You are the SecurityAudit checker-plan resolver.
+Resolve the user's audit intent into an executable JSON plan.
+
+Hard constraints:
+- Select checkers only from allowed_checker_names.
+- Never invent checker names.
+- The local resolver owns schema_version, strategy, and source; do not output them.
+- The Progressive Risk Audit Workflow is the default full-risk workflow:
+  1. quick_scan: cheap full-scan checks for direct leakage and obvious surface risks, then
+  2. semantic_scan: semantic and alignment risks with LLM judges, with risk-based routing to balance cost and coverage, then
+  3. deep_scan: higher-cost specialist model checks for risks such as backdoors, jailbreaks, prompt injection, harmful content, and toxicity, then
+  4. review: optional conditional review for high-risk, low-confidence, near-threshold, or conflicting findings with CrossModelRiskReviewer when it is allowed.
+- For partial-risk requests, remove irrelevant stages or checkers from the workflow.
+- If a requested target cannot be satisfied by the allowed capability set, omit unavailable checkers from stages; the local resolver will derive skipped_checkers and degradations deterministically.
+- Prefer low-cost routing and sampling when the user asks for fast, low-cost, preview, or very large-scale audits.
+- Return JSON only. Do not wrap it in Markdown.
+
+Output schema:
+{output_schema}
+
+Resolver input:
+{resolver_input}
+"""
+
 
 _CHECKER_MIN_RESOURCE_TIERS = {
     **{name: "light" for name in _RULE_BASED_CHECKERS},
@@ -87,8 +228,8 @@ _WEIGHT_SUFFIXES = (".safetensors", ".bin")
 class CheckerRequest:
     selection_mode: str = "default"
     checker_names: list[str] = field(default_factory=list)
-    checker_preferences: str = ""
-    strategy: str = "single_stage"
+    audit_intent: str = ""
+    strategy: str = "llm"
     raw: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -150,15 +291,14 @@ class ResolvedCheckerPlan:
     checker_configs: list[CheckerConfig]
     skipped_checkers: list[dict[str, str]] = field(default_factory=list)
     degradations: list[dict[str, str]] = field(default_factory=list)
+    objective: dict[str, Any] = field(default_factory=dict)
     stages: list[dict[str, Any]] = field(default_factory=list)
     request: CheckerRequest | None = None
     capability_set: CheckerCapabilitySet | None = None
 
 
 def build_checker_request(kwargs: dict, tool_defaults: dict) -> CheckerRequest:
-    # TODO: (resource_tier) Let security_audit strategies accept explicit
-    # strategy names once funnel policies are implemented.
-    strategy = str(kwargs.get("strategy") or tool_defaults.get("strategy") or "single_stage")
+    strategy = str(kwargs.get("strategy") or tool_defaults.get("strategy") or "llm")
     raw = dict(kwargs)
     raw_checker_names = kwargs.get("checker_names")
     has_checker_names = "checker_names" in kwargs
@@ -169,15 +309,15 @@ def build_checker_request(kwargs: dict, tool_defaults: dict) -> CheckerRequest:
         selection_mode = "explicit" if has_checker_names else "default"
 
     checker_names = raw_checker_names if isinstance(raw_checker_names, list) else []
-    raw_checker_preferences = kwargs.get("checker_preferences")
-    checker_preferences = raw_checker_preferences if isinstance(raw_checker_preferences, str) else ""
+    raw_audit_intent = kwargs.get("audit_intent")
+    audit_intent = raw_audit_intent if isinstance(raw_audit_intent, str) else ""
     if selection_mode == "default":
-        checker_preferences = ""
+        audit_intent = ""
 
     return CheckerRequest(
         selection_mode=selection_mode,
         checker_names=_unique_checker_names(checker_names),
-        checker_preferences=checker_preferences,
+        audit_intent=audit_intent,
         strategy=strategy,
         raw=raw,
     )
@@ -213,11 +353,14 @@ def validate_checker_request(
             ),
         ))
 
-    if not isinstance(request.strategy, str) or not request.strategy.strip():
+    if request.strategy not in _RESOLVE_STRATEGIES:
         issues.append(PreflightIssue(
             level="error",
             code="invalid_security_audit_strategy",
-            message="security_audit strategy must be a non-empty string.",
+            message=(
+                "security_audit strategy must be one of "
+                f"{sorted(_RESOLVE_STRATEGIES)}, got {request.strategy!r}."
+            ),
         ))
 
     raw_checker_names = request.raw.get("checker_names")
@@ -232,13 +375,13 @@ def validate_checker_request(
 
     if (
         request.selection_mode != "default"
-        and "checker_preferences" in request.raw
-        and not isinstance(request.raw.get("checker_preferences"), str)
+        and "audit_intent" in request.raw
+        and not isinstance(request.raw.get("audit_intent"), str)
     ):
         issues.append(PreflightIssue(
             level="error",
-            code="invalid_checker_preferences",
-            message="checker_preferences must be a string.",
+            code="invalid_audit_intent",
+            message="audit_intent must be a string.",
         ))
 
     if request.selection_mode != "explicit":
@@ -322,6 +465,10 @@ def resolve_checker_plan(
     capability_set: CheckerCapabilitySet,
     tool_defaults: dict,
     resource_tier: str,
+    llm: Any | None = None,
+    llm_model: str = "",
+    logger: Any | None = None,
+    data_profile: dict[str, Any] | None = None,
 ) -> ResolvedCheckerPlan:
     default_configs = load_default_checker_configs(tool_defaults)
     defaults_by_name = {config.name: config for config in default_configs}
@@ -339,6 +486,20 @@ def resolve_checker_plan(
             checker_configs=checker_configs,
             skipped_checkers=skipped,
             source="explicit",
+        )
+
+    if request.selection_mode == "recommend" and request.strategy == "llm":
+        return _resolve_llm_checker_plan(
+            request=request,
+            capability_set=capability_set,
+            defaults_by_name=defaults_by_name,
+            tool_defaults=tool_defaults,
+            resource_tier=resource_tier,
+            source=request.selection_mode,
+            llm=llm,
+            llm_model=llm_model,
+            logger=logger,
+            data_profile=data_profile,
         )
 
     if request.selection_mode == "recommend":
@@ -525,7 +686,7 @@ def checker_request_metadata(request: CheckerRequest) -> dict[str, Any]:
     return {
         "checker_selection_mode": request.selection_mode,
         "checker_names": list(request.checker_names),
-        "checker_preferences": request.checker_preferences,
+        "audit_intent": request.audit_intent,
     }
 
 
@@ -541,6 +702,7 @@ def resolved_plan_metadata(plan: ResolvedCheckerPlan) -> dict[str, Any]:
         "schema_version": "security_audit.resolved_plan.v1",
         "strategy": plan.strategy,
         "source": plan.source,
+        "objective": dict(plan.objective),
         "stages": list(plan.stages),
         "skipped_checkers": list(plan.skipped_checkers),
         "degradations": list(plan.degradations),
@@ -576,13 +738,412 @@ def _single_stage(checker_names: list[str]) -> dict[str, Any]:
         "name": "single_stage",
         "type": "single_stage",
         "checkers": list(checker_names),
-        "input_scope": {
-            "type": "all_samples",
-            "source_stage_id": None,
-        },
         "routing": {
-            "mode": "all",
+            "mode": "all_samples",
         },
+    }
+
+
+def _resolve_llm_checker_plan(
+    *,
+    request: CheckerRequest,
+    capability_set: CheckerCapabilitySet,
+    defaults_by_name: dict[str, CheckerConfig],
+    tool_defaults: dict,
+    resource_tier: str,
+    source: str,
+    llm: Any | None,
+    llm_model: str,
+    logger: Any | None,
+    data_profile: dict[str, Any] | None,
+) -> ResolvedCheckerPlan:
+    if llm is None or not llm_model:
+        plan = _resolve_default_llm_progressive_workflow_plan(
+            request=request,
+            capability_set=capability_set,
+            defaults_by_name=defaults_by_name,
+            source=source,
+        )
+        plan.strategy = "deterministic"
+        plan.degradations.append({
+            "reason": "llm_resolver_unavailable" if llm is None else "llm_model_unavailable",
+            "from": "llm",
+            "to": "deterministic_progressive_workflow",
+        })
+        return plan
+
+    prompt = build_llm_resolver_prompt(
+        request=request,
+        capability_set=capability_set,
+        resource_tier=resource_tier,
+        tool_defaults=tool_defaults,
+        data_profile=data_profile,
+    )
+    try:
+        if hasattr(llm, "generate_json"):
+            raw_plan = llm.generate_json(
+                llm_model,
+                prompt,
+                temperature=0.0,
+            )
+        else:
+            content = llm.generate(
+                llm_model,
+                prompt,
+                system_prompt="You must respond with valid JSON only.",
+                temperature=0.0,
+            )
+            raw_plan = _load_json_object(content)
+        return _resolved_plan_from_llm_output(
+            raw_plan=raw_plan,
+            request=request,
+            capability_set=capability_set,
+            defaults_by_name=defaults_by_name,
+            source=source,
+        )
+    except Exception as exc:
+        if logger is not None and hasattr(logger, "warning"):
+            logger.warning(f"SecurityAuditTool: LLM resolver failed, falling back to deterministic progressive workflow: {exc}")
+        plan = _resolve_default_llm_progressive_workflow_plan(
+            request=request,
+            capability_set=capability_set,
+            defaults_by_name=defaults_by_name,
+            source=source,
+        )
+        plan.strategy = "deterministic"
+        plan.degradations.append({
+            "reason": "llm_resolver_failed",
+            "from": "llm",
+            "to": "deterministic",
+        })
+        return plan
+
+
+def _resolve_default_llm_progressive_workflow_plan(
+    *,
+    request: CheckerRequest,
+    capability_set: CheckerCapabilitySet,
+    defaults_by_name: dict[str, CheckerConfig],
+    source: str,
+) -> ResolvedCheckerPlan:
+    stages, names, skipped, degradations = build_progressive_workflow_stages(capability_set)
+    checker_configs, config_skipped = _checker_configs_from_names(
+        names=names,
+        defaults_by_name=defaults_by_name,
+        capability_set=capability_set,
+    )
+    return ResolvedCheckerPlan(
+        strategy="llm",
+        checker_configs=checker_configs,
+        skipped_checkers=_dedupe_skip_records(skipped + config_skipped),
+        degradations=degradations,
+        source=source,
+        objective=_default_progressive_workflow_objective(stages),
+        stages=stages,
+        request=request,
+        capability_set=capability_set,
+    )
+
+
+def _resolved_plan_from_llm_output(
+    *,
+    raw_plan: dict[str, Any],
+    request: CheckerRequest,
+    capability_set: CheckerCapabilitySet,
+    defaults_by_name: dict[str, CheckerConfig],
+    source: str,
+) -> ResolvedCheckerPlan:
+    if not isinstance(raw_plan, dict):
+        raise ValueError("LLM resolver output must be a JSON object.")
+
+    raw_stages = raw_plan.get("stages")
+    if not isinstance(raw_stages, list) or not raw_stages:
+        raise ValueError("LLM resolver output must include a non-empty stages list.")
+
+    stages: list[dict[str, Any]] = []
+    selected_names: list[str] = []
+    skipped: list[dict[str, str]] = []
+    degradations: list[dict[str, str]] = []
+
+    for index, raw_stage in enumerate(raw_stages, start=1):
+        if not isinstance(raw_stage, dict):
+            degradations.append({
+                "reason": "llm_stage_not_object",
+                "from": f"stage_{index}",
+                "to": "skip_stage",
+            })
+            continue
+        stage, stage_names, stage_skipped, stage_degradation = _normalize_llm_stage(
+            raw_stage=raw_stage,
+            capability_set=capability_set,
+            index=index,
+        )
+        stages.append(stage)
+        selected_names.extend(stage_names)
+        skipped.extend(stage_skipped)
+        if stage_degradation:
+            degradations.append(stage_degradation)
+
+    selected_names = _unique_in_order(selected_names)
+    if not selected_names:
+        raise ValueError("LLM resolver selected no allowed checkers.")
+
+    checker_configs, config_skipped = _checker_configs_from_names(
+        names=selected_names,
+        defaults_by_name=defaults_by_name,
+        capability_set=capability_set,
+    )
+
+    return ResolvedCheckerPlan(
+        strategy="llm",
+        checker_configs=checker_configs,
+        skipped_checkers=_dedupe_skip_records(skipped + config_skipped),
+        degradations=_dedupe_skip_records(degradations),
+        source=source,
+        objective=_normalize_objective(raw_plan.get("objective"), stages),
+        stages=stages,
+        request=request,
+        capability_set=capability_set,
+    )
+
+
+def _load_json_object(content: str) -> dict[str, Any]:
+    cleaned = str(content or "").strip()
+    if cleaned.startswith("```json"):
+        cleaned = cleaned.split("```json", 1)[1].split("```", 1)[0].strip()
+    elif cleaned.startswith("```"):
+        cleaned = cleaned.split("```", 1)[1].split("```", 1)[0].strip()
+    parsed = json.loads(cleaned)
+    if not isinstance(parsed, dict):
+        raise ValueError("LLM resolver output must be a JSON object.")
+    return parsed
+
+
+def _normalize_llm_stage(
+    *,
+    raw_stage: dict[str, Any],
+    capability_set: CheckerCapabilitySet,
+    index: int,
+) -> tuple[dict[str, Any], list[str], list[dict[str, str]], dict[str, str] | None]:
+    stage_id = _clean_stage_id(raw_stage.get("id"), index)
+    raw_checker_names = raw_stage.get("checkers")
+    checker_names = raw_checker_names if isinstance(raw_checker_names, list) else []
+    allowed_stage_names: list[str] = []
+    skipped: list[dict[str, str]] = []
+
+    for raw_name in checker_names:
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            skipped.append({"name": str(raw_name), "reason": "invalid_checker_name"})
+            continue
+        name = raw_name.strip()
+        capability = capability_set.get(name)
+        if capability and capability.allowed:
+            allowed_stage_names.append(name)
+            continue
+        skipped.append({
+            "name": name,
+            "reason": capability.blocked_reason if capability else "unknown_checker",
+        })
+
+    allowed_stage_names = _unique_in_order(allowed_stage_names)
+    degradation = None
+    if not allowed_stage_names and (checker_names or stage_id != "review"):
+        degradation = {
+            "reason": f"llm_stage_{stage_id}_has_no_allowed_checkers",
+            "from": stage_id,
+            "to": "skip_stage",
+        }
+
+    stage = {
+        "id": stage_id,
+        "name": str(raw_stage.get("name") or stage_id),
+        "type": str(raw_stage.get("type") or stage_id),
+        "risk_focus": _coerce_string_list(raw_stage.get("risk_focus")),
+        "checkers": allowed_stage_names,
+        "routing": _normalize_routing(raw_stage.get("routing")),
+        "purpose": str(raw_stage.get("purpose") or ""),
+    }
+    return stage, allowed_stage_names, skipped, degradation
+
+
+
+def _normalize_objective(raw_objective: Any, stages: list[dict[str, Any]]) -> dict[str, Any]:
+    if not isinstance(raw_objective, dict):
+        return _default_progressive_workflow_objective(stages)
+    return {
+        "goal": str(raw_objective.get("goal") or "security_audit"),
+        "covered_risk_types": _coerce_string_list(
+            raw_objective.get("covered_risk_types")
+        ) or _unique_in_order([
+            risk
+            for stage in stages
+            for risk in stage.get("risk_focus", [])
+        ]),
+        "optimization": _coerce_string_list(raw_objective.get("optimization")),
+    }
+
+
+def _default_progressive_workflow_objective(stages: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "goal": "full_risk_coverage",
+        "covered_risk_types": _unique_in_order([
+            risk
+            for stage in stages
+            for risk in stage.get("risk_focus", [])
+        ]),
+        "optimization": ["coverage"],
+    }
+
+
+def _normalize_routing(raw_routing: Any) -> dict[str, Any]:
+    routing = dict(raw_routing) if isinstance(raw_routing, dict) else {}
+    routing["mode"] = str(routing.get("mode") or "all_samples")
+    if routing.get("source_stage_id"):
+        routing["source_stage_id"] = str(routing["source_stage_id"])
+    if "rules" in routing and not isinstance(routing["rules"], list):
+        routing["rules"] = [str(routing["rules"])]
+    return routing
+
+
+def _clean_stage_id(value: Any, index: int) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return f"stage_{index}"
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    items: list[str] = []
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            items.append(item.strip())
+    return _unique_in_order(items)
+
+
+
+def build_progressive_workflow_stages(
+    capability_set: CheckerCapabilitySet,
+) -> tuple[list[dict[str, Any]], list[str], list[dict[str, str]], list[dict[str, str]]]:
+    stages: list[dict[str, Any]] = []
+    selected_names: list[str] = []
+    skipped: list[dict[str, str]] = []
+    degradations: list[dict[str, str]] = []
+
+    for template in _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS:
+        stage, stage_names, stage_skipped, stage_degradation = build_progressive_workflow_stage(
+            template=template,
+            capability_set=capability_set,
+        )
+        stages.append(stage)
+        selected_names.extend(stage_names)
+        skipped.extend(stage_skipped)
+        if stage_degradation:
+            degradations.append(stage_degradation)
+
+    return stages, _unique_in_order(selected_names), _dedupe_skip_records(skipped), degradations
+
+
+def build_progressive_workflow_stage(
+    *,
+    template: dict[str, Any],
+    capability_set: CheckerCapabilitySet,
+) -> tuple[dict[str, Any], list[str], list[dict[str, str]], dict[str, str] | None]:
+    allowed_stage_names: list[str] = []
+    skipped: list[dict[str, str]] = []
+
+    for name in template["checkers"]:
+        capability = capability_set.get(name)
+        if capability and capability.allowed:
+            allowed_stage_names.append(name)
+            continue
+        skipped.append({
+            "name": name,
+            "reason": capability.blocked_reason if capability else "unknown_checker",
+        })
+
+    degradation = None
+    if not allowed_stage_names and template["checkers"]:
+        degradation = {
+            "reason": f"progressive_workflow_stage_{template['id']}_has_no_allowed_checkers",
+            "from": template["id"],
+            "to": "skip_stage",
+        }
+
+    stage = {
+        "id": template["id"],
+        "name": template["name"],
+        "type": template["type"],
+        "risk_focus": list(template["risk_focus"]),
+        "checkers": allowed_stage_names,
+        "routing": dict(template["routing"]),
+        "purpose": template["purpose"],
+    }
+    return stage, allowed_stage_names, skipped, degradation
+
+
+def _unique_in_order(names: list[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        if name in seen:
+            continue
+        seen.add(name)
+        unique.append(name)
+    return unique
+
+
+def _dedupe_skip_records(records: list[dict[str, str]]) -> list[dict[str, str]]:
+    deduped: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for record in records:
+        name = record.get("name", "")
+        reason = record.get("reason", "")
+        key = (name, reason)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(record)
+    return deduped
+
+
+def build_llm_resolver_prompt(
+    *,
+    request: CheckerRequest,
+    capability_set: CheckerCapabilitySet,
+    resource_tier: str,
+    tool_defaults: dict,
+    data_profile: dict[str, Any] | None = None,
+) -> str:
+    resolver_input = {
+        "request": checker_request_metadata(request),
+        "runtime_policy": {"resource_tier": resource_tier},
+        "data_profile": data_profile or {},
+        "capability_set": {
+            "allowed_checker_names": capability_set.allowed_names(),
+            "blocked_checkers": capability_set.blocked_metadata(),
+            "allowed_checkers": [
+                _checker_card_for_prompt(capability)
+                for capability in capability_set.capabilities.values()
+                if capability.allowed
+            ],
+        },
+        "risk_weights": tool_defaults.get("risk_weights", {}),
+        "progressive_workflow_reference": _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS,
+    }
+    return LLM_RESOLVER_PROMPT_TEMPLATE.format(
+        output_schema=json.dumps(LLM_RESOLVER_OUTPUT_SCHEMA, ensure_ascii=False, indent=2),
+        resolver_input=json.dumps(resolver_input, ensure_ascii=False, indent=2),
+    )
+
+
+def _checker_card_for_prompt(capability: CheckerCapability) -> dict[str, Any]:
+    return {
+        "name": capability.name,
+        "checker_type": capability.checker_type,
+        "risk_type": capability.risk_type,
+        "required_tier": capability.required_tier,
+        "params": capability.params,
     }
 
 
@@ -621,17 +1182,17 @@ def _recommend_checker_names(
     resource_tier: str,
 ) -> tuple[list[str], list[dict[str, str]]]:
     allowed = set(capability_set.allowed_names())
-    preference = request.checker_preferences.lower()
+    intent = request.audit_intent.lower()
 
     fast_markers = ("fast", "quick", "low cost", "low-cost", "cheap", "light", "成本", "快速", "低成本")
     broad_markers = ("accurate", "accuracy", "coverage", "strong", "full", "全面", "准确", "覆盖")
 
-    if any(marker in preference for marker in fast_markers):
+    if any(marker in intent for marker in fast_markers):
         names = [name for name in _RULE_BASED_CHECKERS if name in allowed]
         if names:
             return names, []
 
-    if any(marker in preference for marker in broad_markers):
+    if any(marker in intent for marker in broad_markers):
         names = [
             name for name in _coverage_checker_names_for_resource_tier(resource_tier)
             if name in allowed

--- a/tools/security_audit/policy.py
+++ b/tools/security_audit/policy.py
@@ -47,7 +47,6 @@ _HEAVY_MODEL_CHECKERS = [
     "BiasClassifier",
     "JailbreakClassifier",
     "PromptInjectionClassifier",
-    "CrossModelRiskReviewer",
     "GraCeFulBackdoorDefender",
 ]
 
@@ -55,10 +54,49 @@ _RESOURCE_TIER_ORDER = {"light": 0, "standard": 1, "full": 2}
 
 _RESOLVE_STRATEGIES = {"deterministic", "llm"}
 
+_ROUTING_MODES = {"all_samples", "field_applicable", "uncertain", "sample"}
+_ROUTING_RULES = {
+    "near_threshold",
+    "conflicting",
+    "low_confidence",
+    "error",
+    "content_filter",
+    "unflagged",
+}
+_ROUTING_FIELDS = {
+    "messages",
+    "response",
+    "chosen_response",
+    "rejected_response",
+    "context",
+    "ground_truth_answer",
+    "reference_answer",
+}
+_ROUTING_DATASET_TYPES = {"sft", "rl", "dpo", "benchmark"}
+
+_ROUTING_KEYS = {
+    "mode",
+    "source_stage_id",
+    "rules",
+    "rule",
+    "dataset_types",
+    "dataset_type",
+    "required_fields",
+    "fields",
+    "sample_rate",
+    "rate",
+    "sample_size",
+    "max_samples",
+    "limit",
+    "threshold",
+    "threshold_margin",
+    "margin",
+}
+
 _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
     {
         "id": "stage_1",
-        "name": "quick_scan",
+        "name": "quick_surface_scan",
         "type": "quick_scan",
         "risk_focus": ["pii", "secret", "harmful", "toxicity", "bias"],
         "checkers": [
@@ -70,23 +108,19 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
             "PIINERDetector",
         ],
         "routing": {"mode": "all_samples"},
-        "purpose": "Run cheap full-scan checks for direct leakage and obvious surface risks before semantic review.",
+        "purpose": "Optional low-cost pre-screen for fast or budget-constrained audits; skip this stage when the user prioritizes high precision and high recall over cost.",
     },
     {
         "id": "stage_2",
-        "name": "semantic_scan",
+        "name": "semantic_safety_scan",
         "type": "semantic_scan",
         "risk_focus": [
+            "pii",
             "harmful",
             "toxicity",
             "bias",
             "prompt_injection",
             "jailbreak",
-            "instruction_mismatch",
-            "label_flipping",
-            "factual_inconsistency",
-            "self_contradiction",
-            "sycophancy",
         ],
         "checkers": [
             "PIILLMJudge",
@@ -95,31 +129,98 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
             "BiasLLMJudge",
             "PromptInjectionLLMJudge",
             "JailbreakLLMJudge",
-            "InstructionMismatchLLMJudge",
-            "DPOLabelFlipLLMJudge",
-            "FactualInconsistancyLLMJudge",
-            "SelfContradictionLLMJudge",
-            "SycophancyLLMJudge",
         ],
-        "routing": {
-            "mode": "field_applicable",
-        },
-        "purpose": "Find semantic safety, poisoning, alignment bypass, and dataset-label risks.",
+        "routing": {"mode": "all_samples"},
+        "purpose": "Review semantic safety and alignment-bypass risks on samples with auditable text.",
     },
     {
         "id": "stage_3",
-        "name": "deep_scan",
+        "name": "instruction_following_scan",
+        "type": "semantic_scan",
+        "risk_focus": ["instruction_mismatch"],
+        "checkers": ["InstructionMismatchLLMJudge"],
+        "routing": {
+            "mode": "field_applicable",
+            "required_fields": ["response"],
+        },
+        "purpose": "Audit whether responses follow instructions only when both instructions/messages and a response are present.",
+    },
+    {
+        "id": "stage_4",
+        "name": "self_contradiction_scan",
+        "type": "semantic_scan",
+        "risk_focus": ["self_contradiction"],
+        "checkers": ["SelfContradictionLLMJudge"],
+        "routing": {
+            "mode": "field_applicable",
+            "required_fields": ["response"],
+        },
+        "purpose": "Audit internal response contradictions only on samples that contain a model response or assistant message.",
+    },
+    {
+        "id": "stage_5",
+        "name": "sycophancy_scan",
+        "type": "semantic_scan",
+        "risk_focus": ["sycophancy"],
+        "checkers": ["SycophancyLLMJudge"],
+        "routing": {
+            "mode": "field_applicable",
+            "required_fields": ["response"],
+        },
+        "purpose": "Audit sycophancy only when user messages and a model response are available.",
+    },
+    {
+        "id": "stage_6",
+        "name": "dpo_pairwise_scan",
+        "type": "semantic_scan",
+        "risk_focus": ["label_flipping"],
+        "checkers": ["DPOLabelFlipLLMJudge"],
+        "routing": {
+            "mode": "field_applicable",
+            "dataset_types": ["dpo"],
+            "required_fields": ["chosen_response", "rejected_response"],
+        },
+        "purpose": "Audit DPO preference pairs independently from general semantic stages because the checker requires chosen and rejected responses.",
+    },
+    {
+        "id": "stage_7",
+        "name": "factual_consistency_scan",
+        "type": "semantic_scan",
+        "risk_focus": ["factual_inconsistency"],
+        "checkers": ["FactualInconsistancyLLMJudge"],
+        "routing": {
+            "mode": "field_applicable",
+            "required_fields": ["context"],
+        },
+        "purpose": "Audit factual consistency only when trusted context and a response are present.",
+    },
+    {
+        "id": "stage_8",
+        "name": "backdoor_scan",
         "type": "deep_scan",
         "risk_focus": [
-            "backdoor",
+            "backdoor"
+        ],
+        "checkers": [
+            "GraCeFulBackdoorDefender"
+        ],
+        "routing": {
+            "mode": "all_samples",
+        },
+        "purpose": "Scan backdoors.",
+    },
+    {
+        "id": "stage_9",
+        "name": "risk_review",
+        "type": "deep_scan",
+        "risk_focus": [
+            "jailbreak",
+            "prompt_injection",
             "harmful",
             "toxicity",
             "bias",
-            "jailbreak",
-            "prompt_injection",
         ],
         "checkers": [
-            "GraCeFulBackdoorDefender",
             "HarmfulContentClassifier",
             "ToxicityClassifier",
             "BiasClassifier",
@@ -127,24 +228,12 @@ _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS = [
             "PromptInjectionClassifier",
         ],
         "routing": {
-            "mode": "high_risk_partition",
+            "mode": "uncertain",
             "source_stage_id": "stage_2",
+            "rules": ["error", "content_filter", "near_threshold", "low_confidence"],
         },
-        "purpose": "Run higher-cost specialist model checks when resources allow it, prioritizing sampled data, high-risk partitions, and upstream flagged samples.",
-    },
-    # TODO: Add a fourth review stage with CrossModelRiskReviewer for high-risk, low-confidence, near-threshold, or conflicting findings from earlier stages.
-    # {
-    #     "id": "stage_4",
-    #     "name": "review",
-    #     "type": "review",
-    #     "risk_focus": ["cross_model_review", "uncertainty_review"],
-    #     "checkers": ["CrossModelRiskReviewer"],
-    #     "routing": {
-    #         "mode": "uncertain",
-    #         "source_stage_id": "stage_3",
-    #     },
-    #     "purpose": "Conditionally review high-risk, low-confidence, near-threshold, or conflicting findings with CrossModelRiskReviewer.",
-    # },
+        "purpose": "Review samples flagged for potential risks.",
+    }
 ]
 
 LLM_RESOLVER_OUTPUT_SCHEMA: dict[str, Any] = {
@@ -157,12 +246,19 @@ LLM_RESOLVER_OUTPUT_SCHEMA: dict[str, Any] = {
         {
             "id": "stage_number",
             "name": "string",
-            "type": "quick_scan|semantic_scan|deep_scan|review",
+            "type": "quick_scan|semantic_scan|deep_scan",
+            "risk_focus": ["risk_type_name"],
             "checkers": ["CheckerClassName"],
             "routing": {
-                "mode": "all_samples|field_applicable|uncertain|sample|high_risk_partition",
+                "mode": "all_samples|field_applicable|uncertain|sample",
                 "source_stage_id": "string|null",
-                "rules": ["string"],
+                "rules": ["near_threshold|conflicting|low_confidence|error|content_filter|unflagged"],
+                "dataset_types": ["sft|rl|dpo|benchmark"],
+                "required_fields": ["messages|response|chosen_response|rejected_response|context|ground_truth_answer|reference_answer"],
+                "sample_rate": "optional number",
+                "sample_size": "optional number",
+                "threshold": "optional number",
+                "threshold_margin": "optional number",
             },
             "purpose": "string",
         }
@@ -176,14 +272,29 @@ Hard constraints:
 - Select checkers only from allowed_checker_names.
 - Never invent checker names.
 - The local resolver owns schema_version, strategy, and source; do not output them.
-- The Progressive Risk Audit Workflow is the default full-risk workflow:
-  1. quick_scan: cheap full-scan checks for direct leakage and obvious surface risks, then
-  2. semantic_scan: semantic and alignment risks with LLM judges, with risk-based routing to balance cost and coverage, then
-  3. deep_scan: higher-cost specialist model checks for risks such as backdoors, jailbreaks, prompt injection, harmful content, and toxicity, then
-  4. review: optional conditional review for high-risk, low-confidence, near-threshold, or conflicting findings with CrossModelRiskReviewer when it is allowed.
+- Do not force a fixed three-stage plan. The stage list is a flexible execution plan; use as many or as few stages as the audit intent requires.
+- Prefer a non-empty risk_focus list for every stage. Put risk names in stage.risk_focus.
+- Prefer not to reuse the same checker in multiple stages. Later stages should usually use stronger or more specialized checkers rather than rerunning earlier cheap/checker stages.
+- A review stage must use checker(s) for the same risk type that have not already appeared earlier in the plan, and those checker(s) should be stronger or more specialized than the upstream checker(s). If no unused stronger/specialized checker is available for that risk type, skip the review stage instead of rerunning earlier checker(s).
+- Build funnel-style plans only when they match the user intent. For fast or low-cost audits, cheap rule-based checks can run first. For high-precision and high-recall audits, skip low-precision/low-recall rule-based quick_scan stages and start from stronger LLM judges or model/guard checkers. Later stages should use stronger or more specialized checkers, not repeat earlier checkers.
+- A stage should group checkers that share similar cost, data applicability, and routing. Split checkers into separate stages when they need different dataset types, required fields, upstream source stages, sampling, or review rules.
+- Treat the Progressive Risk Audit Workflow as a menu of reusable stage patterns, not a required sequence. You may remove, reorder, merge, or split patterns as long as dependencies are valid. In particular, quick_scan is optional and should be omitted when it does not improve the requested precision/recall objective.
+- Field-specific checks should usually be independent stages with explicit routing, but required_fields may only contain real DataSample fields. Examples: DPOLabelFlipLLMJudge uses dataset_types=["dpo"] and required_fields=["chosen_response", "rejected_response"]; FactualInconsistancyLLMJudge uses required_fields=["context"]; InstructionMismatchLLMJudge and SycophancyLLMJudge use required_fields=["response"]. Do not output virtual field names.
 - For partial-risk requests, remove irrelevant stages or checkers from the workflow.
 - If a requested target cannot be satisfied by the allowed capability set, omit unavailable checkers from stages; the local resolver will derive skipped_checkers and degradations deterministically.
-- Prefer low-cost routing and sampling when the user asks for fast, low-cost, preview, or very large-scale audits.
+- Prefer low-cost routing, sampling, and rule-based checkers only when the user asks for fast, low-cost, preview, or very large-scale audits. Do not include rule-based checkers by default for high-precision high-recall audits unless they are explicitly requested or provide unique coverage such as secrets.
+
+Routing guidance:
+- routing may only contain these keys: mode, source_stage_id, rules, dataset_types, required_fields, sample_rate, sample_size, threshold, threshold_margin.
+- Do not put risk_types or checker_names inside routing; use stage.risk_focus and stage.checkers instead.
+- Use mode=all_samples only for checks that should run over every sample. Rule-based all-sample quick scans are mainly for fast/low-cost pre-screening, not mandatory for high-precision high-recall plans.
+- Use mode=field_applicable for checks that require specific real DataSample fields or dataset types; add required_fields and dataset_types when known.
+- Use mode=sample for low-cost previews over applicable samples, or for expensive specialist checks when cost control is requested; set sample_rate or sample_size only with mode=sample.
+- Use mode=uncertain only for a later review/recall stage with unused stronger/specialized checker(s) for the same risk type as the source stage. For high-precision review, use rules such as ["near_threshold", "conflicting", "low_confidence"], usually with threshold=0.5 and threshold_margin=0.1. For high-recall second-pass scanning, use rules=["unflagged"] to route samples not flagged by the source stage to a stronger checker. If all suitable checkers for that risk type have already been used or are unavailable, omit the uncertain review stage.
+- source_stage_id must reference an earlier stage id in your output.
+- Omit optional routing keys when they are not needed; do not output null values for sample_rate, sample_size, threshold, or threshold_margin.
+- Do not mix unflagged with near_threshold/low_confidence/conflicting unless the user explicitly asks for both high recall and boundary-case review.
+
 - Return JSON only. Do not wrap it in Markdown.
 
 Output schema:
@@ -587,7 +698,26 @@ def validate_resolved_checker_plan(
 
     enabled_names = {config.name for config in enabled_configs}
     stage_names: set[str] = set()
+    seen_stage_ids: set[str] = set()
     for stage in plan.stages:
+        stage_id = str(stage.get("id") or "")
+        if not stage_id.strip():
+            issues.append(PreflightIssue(
+                level="error",
+                code="invalid_stage_id",
+                message="Resolved stages must have a non-empty id.",
+            ))
+        elif stage_id in seen_stage_ids:
+            issues.append(PreflightIssue(
+                level="error",
+                code="duplicate_stage_id",
+                message=f"Resolved stage id `{stage_id}` is duplicated.",
+            ))
+
+        issues.extend(_validate_stage_routing(stage=stage, prior_stage_ids=seen_stage_ids))
+        if stage_id.strip():
+            seen_stage_ids.add(stage_id)
+
         stage_checkers = stage.get("checkers", [])
         if not isinstance(stage_checkers, list):
             issues.append(PreflightIssue(
@@ -679,6 +809,177 @@ def validate_resolved_checker_plan(
                         "when deployment.network_mode=offline."
                     ),
                 ))
+    return issues
+
+
+def _validate_stage_routing(
+    *,
+    stage: dict[str, Any],
+    prior_stage_ids: set[str],
+) -> list[PreflightIssue]:
+    issues: list[PreflightIssue] = []
+    stage_id = str(stage.get("id") or "")
+    routing = stage.get("routing") if isinstance(stage.get("routing"), dict) else {}
+    for key in routing:
+        if key not in _ROUTING_KEYS:
+            issues.append(PreflightIssue(
+                level="error",
+                code="unsupported_stage_routing_key",
+                message=(
+                    f"Resolved stage {stage_id!r} routing contains unsupported key {key!r}. "
+                    f"Allowed keys: {sorted(_ROUTING_KEYS)}."
+                ),
+            ))
+
+    mode = str(routing.get("mode") or "all_samples").strip()
+
+    if mode not in _ROUTING_MODES:
+        issues.append(PreflightIssue(
+            level="error",
+            code="invalid_stage_routing_mode",
+            message=(
+                f"Resolved stage `{stage_id}` has unsupported routing.mode `{mode}`. "
+                f"Allowed modes: {sorted(_ROUTING_MODES)}."
+            ),
+        ))
+
+    source_stage_id = routing.get("source_stage_id")
+    if mode == "uncertain":
+        if not source_stage_id:
+            issues.append(PreflightIssue(
+                level="error",
+                code="missing_stage_routing_source",
+                message=f"Resolved stage `{stage_id}` uses routing.mode='uncertain' but has no source_stage_id.",
+            ))
+        elif str(source_stage_id) not in prior_stage_ids:
+            issues.append(PreflightIssue(
+                level="error",
+                code="invalid_stage_routing_source",
+                message=(
+                    f"Resolved stage `{stage_id}` references source_stage_id `{source_stage_id}`, "
+                    "which is not an earlier stage id."
+                ),
+            ))
+    elif source_stage_id and str(source_stage_id) not in prior_stage_ids:
+        issues.append(PreflightIssue(
+            level="error",
+            code="invalid_stage_routing_source",
+            message=(
+                f"Resolved stage `{stage_id}` references source_stage_id `{source_stage_id}`, "
+                "which is not an earlier stage id."
+            ),
+        ))
+
+    for field in _routing_string_values(routing.get("required_fields") or routing.get("fields")):
+        if field not in _ROUTING_FIELDS:
+            issues.append(PreflightIssue(
+                level="error",
+                code="invalid_stage_routing_field",
+                message=(
+                    f"Resolved stage `{stage_id}` has unsupported required field `{field}`. "
+                    f"Allowed fields: {sorted(_ROUTING_FIELDS)}."
+                ),
+            ))
+
+    for dataset_type in _routing_string_values(routing.get("dataset_types") or routing.get("dataset_type")):
+        if dataset_type not in _ROUTING_DATASET_TYPES:
+            issues.append(PreflightIssue(
+                level="error",
+                code="invalid_stage_routing_dataset_type",
+                message=(
+                    f"Resolved stage `{stage_id}` has unsupported dataset type `{dataset_type}`. "
+                    f"Allowed dataset types: {sorted(_ROUTING_DATASET_TYPES)}."
+                ),
+            ))
+
+    for rule in _routing_string_values(routing.get("rules") or routing.get("rule")):
+        if rule not in _ROUTING_RULES:
+            issues.append(PreflightIssue(
+                level="error",
+                code="invalid_stage_routing_rule",
+                message=(
+                    f"Resolved stage `{stage_id}` has unsupported routing rule `{rule}`. "
+                    f"Allowed rules: {sorted(_ROUTING_RULES)}."
+                ),
+            ))
+
+    issues.extend(_validate_stage_routing_number(
+        stage_id=stage_id,
+        routing=routing,
+        keys=("sample_rate", "rate"),
+        minimum=0.0,
+        maximum=1.0,
+        integer=False,
+    ))
+    issues.extend(_validate_stage_routing_number(
+        stage_id=stage_id,
+        routing=routing,
+        keys=("sample_size", "max_samples", "limit"),
+        minimum=0.0,
+        maximum=None,
+        integer=True,
+    ))
+    issues.extend(_validate_stage_routing_number(
+        stage_id=stage_id,
+        routing=routing,
+        keys=("threshold",),
+        minimum=0.0,
+        maximum=1.0,
+        integer=False,
+    ))
+    issues.extend(_validate_stage_routing_number(
+        stage_id=stage_id,
+        routing=routing,
+        keys=("threshold_margin", "margin"),
+        minimum=0.0,
+        maximum=1.0,
+        integer=False,
+    ))
+    return issues
+
+
+def _routing_string_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip().lower().replace("-", "_") for item in value.split(",") if item.strip()]
+    if isinstance(value, list):
+        return [str(item).strip().lower().replace("-", "_") for item in value if str(item).strip()]
+    return [str(value).strip().lower().replace("-", "_")]
+
+
+def _validate_stage_routing_number(
+    *,
+    stage_id: str,
+    routing: dict[str, Any],
+    keys: tuple[str, ...],
+    minimum: float,
+    maximum: float | None,
+    integer: bool,
+) -> list[PreflightIssue]:
+    issues: list[PreflightIssue] = []
+    for key in keys:
+        if key not in routing:
+            continue
+        raw_value = routing.get(key)
+        if raw_value is None:
+            continue
+        try:
+            value = int(raw_value) if integer else float(raw_value)
+        except (TypeError, ValueError):
+            issues.append(PreflightIssue(
+                level="error",
+                code="invalid_stage_routing_number",
+                message=f"Resolved stage `{stage_id}` routing.{key} must be numeric, got {raw_value!r}.",
+            ))
+            continue
+        if value < minimum or (maximum is not None and value > maximum):
+            upper = f" and <= {maximum}" if maximum is not None else ""
+            issues.append(PreflightIssue(
+                level="error",
+                code="stage_routing_number_out_of_range",
+                message=f"Resolved stage `{stage_id}` routing.{key} must be >= {minimum}{upper}, got {raw_value!r}.",
+            ))
     return issues
 
 
@@ -956,17 +1257,30 @@ def _normalize_llm_stage(
             "to": "skip_stage",
         }
 
+    risk_focus = _coerce_string_list(raw_stage.get("risk_focus"))
+    if not risk_focus:
+        risk_focus = _risk_focus_from_checker_names(allowed_stage_names)
+
     stage = {
         "id": stage_id,
         "name": str(raw_stage.get("name") or stage_id),
         "type": str(raw_stage.get("type") or stage_id),
-        "risk_focus": _coerce_string_list(raw_stage.get("risk_focus")),
+        "risk_focus": risk_focus,
         "checkers": allowed_stage_names,
         "routing": _normalize_routing(raw_stage.get("routing")),
         "purpose": str(raw_stage.get("purpose") or ""),
     }
     return stage, allowed_stage_names, skipped, degradation
 
+
+
+def _risk_focus_from_checker_names(checker_names: list[str]) -> list[str]:
+    risks: list[str] = []
+    for checker_name in checker_names:
+        risk_type = _risk_type(checker_name)
+        if risk_type:
+            risks.append(risk_type)
+    return _unique_in_order(risks)
 
 
 def _normalize_objective(raw_objective: Any, stages: list[dict[str, Any]]) -> dict[str, Any]:
@@ -1131,7 +1445,7 @@ def build_llm_resolver_prompt(
             ],
         },
         "risk_weights": tool_defaults.get("risk_weights", {}),
-        "progressive_workflow_reference": _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS,
+        "stage_pattern_reference": _PROGRESSIVE_WORKFLOW_STAGE_CHECKERS,
     }
     return LLM_RESOLVER_PROMPT_TEMPLATE.format(
         output_schema=json.dumps(LLM_RESOLVER_OUTPUT_SCHEMA, ensure_ascii=False, indent=2),

--- a/tools/security_audit/policy.py
+++ b/tools/security_audit/policy.py
@@ -8,18 +8,64 @@ from config import PreflightIssue, RuntimePolicy
 from .config import CheckerConfig
 
 
-_MODEL_PATH_KEYS = {
-    "HarmfulContentClassifier": "harmful_content_classifier",
-    "JailbreakClassifier": "jailbreak_classifier",
-    "PromptInjectionClassifier": "prompt_injection_classifier",
-    "BiasClassifier": "bias_classifier",
+_RULE_BASED_CHECKERS = [
+    "PIIRule",
+    "SecretRule",
+    "ToxicityKeywordRule",
+    "HarmfulKeywordRule",
+    "BiasKeywordRule",
+]
+
+_LLM_JUDGE_CHECKERS = [
+    "HarmfulContentLLMJudge",
+    "BiasLLMJudge",
+    "ToxicityLLMJudge",
+    "PIILLMJudge",
+    "SycophancyLLMJudge",
+    "PromptInjectionLLMJudge",
+    "JailbreakLLMJudge",
+    "FactualInconsistancyLLMJudge",
+    "SelfContradictionLLMJudge",
+    "InstructionMismatchLLMJudge",
+    "DPOLabelFlipLLMJudge",
+]
+
+_STANDARD_MODEL_CHECKERS = [
+    "PIINERDetector",
+]
+
+_HEAVY_MODEL_CHECKERS = [
+    "HarmfulContentClassifier",
+    "ToxicityClassifier",
+    "BiasClassifier",
+    "JailbreakClassifier",
+    "PromptInjectionClassifier",
+    "GraCeFulBackdoorDefender",
+]
+
+_HEAVY_CHECKERS = set(_HEAVY_MODEL_CHECKERS)
+
+_RESOURCE_TIER_ORDER = {"light": 0, "standard": 1, "full": 2}
+
+_CHECKER_MIN_RESOURCE_TIERS = {
+    **{name: "light" for name in _RULE_BASED_CHECKERS},
+    **{name: "standard" for name in _LLM_JUDGE_CHECKERS},
+    **{name: "standard" for name in _STANDARD_MODEL_CHECKERS},
+    **{name: "full" for name in _HEAVY_MODEL_CHECKERS},
 }
+
+_LOCAL_MODEL_PATH_CHECKERS = {
+    "HarmfulContentClassifier",
+    "JailbreakClassifier",
+    "PromptInjectionClassifier",
+    "BiasClassifier",
+}
+
 
 
 def validate_selected_checkers(
     *,
     checker_configs: list[CheckerConfig],
-    tool_defaults: dict[str, Any],
     runtime_policy: RuntimePolicy,
     context_config: dict[str, Any],
 ) -> list[PreflightIssue]:
@@ -27,16 +73,19 @@ def validate_selected_checkers(
     for checker_config in checker_configs:
         if not checker_config.enabled:
             continue
+        resource_issues = validate_checker_resource_tier_availability(
+            checker_config=checker_config,
+            runtime_policy=runtime_policy,
+        )
+        issues.extend(resource_issues)
+        if not checker_config.enabled:
+            continue
+        if any(issue.level == "error" for issue in resource_issues):
+            continue
         issues.extend(validate_checker_network_availability(
             checker_config=checker_config,
-            tool_defaults=tool_defaults,
             runtime_policy=runtime_policy,
             context_config=context_config,
-        ))
-        issues.extend(validate_checker_resource_tier_availability(
-            checker_config=checker_config,
-            tool_defaults=tool_defaults,
-            runtime_policy=runtime_policy,
         ))
     return issues
 
@@ -44,7 +93,6 @@ def validate_selected_checkers(
 def validate_checker_network_availability(
     *,
     checker_config: CheckerConfig,
-    tool_defaults: dict[str, Any],
     runtime_policy: RuntimePolicy,
     context_config: dict[str, Any],
 ) -> list[PreflightIssue]:
@@ -66,9 +114,8 @@ def validate_checker_network_availability(
             ),
         )]
 
-    if name in _MODEL_PATH_KEYS:
-        model_key = _MODEL_PATH_KEYS[name]
-        model_path = _resolve_model_path(checker_config, tool_defaults, model_key)
+    if name in _LOCAL_MODEL_PATH_CHECKERS:
+        model_path = _resolve_model_path(checker_config)
         if not model_path:
             return [PreflightIssue(
                 level="error",
@@ -76,8 +123,8 @@ def validate_checker_network_availability(
                 checker_name=name,
                 message=(
                     "Offline model-based checker requires a local model path. "
-                    f"Set tool_defaults.security_audit.models.{model_key} or pass "
-                    "checker params.model_name_or_path."
+                    "Set checker params.model_name_or_path in "
+                    "tools/security_audit/default.yaml."
                 ),
             )]
         if not _path_exists(model_path):
@@ -118,27 +165,60 @@ def validate_checker_network_availability(
 def validate_checker_resource_tier_availability(
     *,
     checker_config: CheckerConfig,
-    tool_defaults: dict[str, Any],
     runtime_policy: RuntimePolicy,
 ) -> list[PreflightIssue]:
-    # TODO: (resource_tier) Intern-owned implementation. Keep this flexible:
-    # define checker min_tier metadata and default checker pools for
-    # light/standard/full. Keep provenance simple for now: this layer validates
-    # the final selected checkers rather than tracking whether they came from
-    # user text, generated DSL, or config defaults.
-    return []
+
+    name = checker_config.name
+    required_tier = _CHECKER_MIN_RESOURCE_TIERS.get(name)
+    if required_tier is None:
+        return []
+
+    current_tier = runtime_policy.resource_tier
+    current_rank = _RESOURCE_TIER_ORDER.get(current_tier)
+    required_rank = _RESOURCE_TIER_ORDER[required_tier]
+    if current_rank is None or current_rank >= required_rank:
+        return []
+
+    source = getattr(checker_config, "selection_source", "config")
+    if source != "explicit":
+        checker_config.enabled = False
+        return [PreflightIssue(
+            level="warning",
+            code="checker_filtered_by_resource_tier",
+            checker_name=name,
+            message=(
+                f"Checker `{name}` requires deployment.resource_tier >= {required_tier!r}, "
+                f"but current resource_tier is {current_tier!r}; "
+                f"it was disabled from the {source} checker selection."
+            ),
+        )]
+
+    return [PreflightIssue(
+        level="error",
+        code="checker_resource_tier_too_low",
+        checker_name=name,
+        message=(
+            f"Checker `{name}` requires deployment.resource_tier >= {required_tier!r}, "
+            f"but current resource_tier is {current_tier!r}."
+        ),
+    )]
+
 
 
 def resolve_default_checkers_for_resource_tier(resource_tier: str) -> list[str]:
-    # TODO: (resource_tier) Replace this placeholder with light/standard/full
-    # default checker sets and, later, funnel-routing strategy selection.
-    return [
-        "PIIRule",
-        "SecretRule",
-        "ToxicityKeywordRule",
-        "HarmfulKeywordRule",
-        "BiasKeywordRule",
-    ]
+    normalized = (resource_tier or "light").strip().lower()
+    if normalized == "standard":
+        return [
+            *_STANDARD_MODEL_CHECKERS,
+            *_LLM_JUDGE_CHECKERS,
+        ]
+    if normalized == "full":
+        return [
+            *_STANDARD_MODEL_CHECKERS,
+            *_LLM_JUDGE_CHECKERS,
+            *_HEAVY_MODEL_CHECKERS,
+        ]
+    return list(_RULE_BASED_CHECKERS)
 
 
 def _has_local_llm_config(context_config: dict[str, Any]) -> bool:
@@ -150,17 +230,9 @@ def _has_local_llm_config(context_config: dict[str, Any]) -> bool:
     )
 
 
-def _resolve_model_path(
-    checker_config: CheckerConfig,
-    tool_defaults: dict[str, Any],
-    model_key: str,
-) -> str | None:
+def _resolve_model_path(checker_config: CheckerConfig) -> str | None:
     explicit = checker_config.params.get("model_name_or_path")
-    if explicit:
-        return str(explicit)
-    models = tool_defaults.get("models") if isinstance(tool_defaults.get("models"), dict) else {}
-    value = models.get(model_key)
-    return str(value) if value else None
+    return str(explicit) if explicit else None
 
 
 def _path_exists(value: str) -> bool:

--- a/tools/security_audit/result.py
+++ b/tools/security_audit/result.py
@@ -46,17 +46,20 @@ class SampleReport(BaseModel):
         CheckResult). Unchecked categories are omitted from scores and flags.
 
         Each category score is the max score across all checkers for that category.
-        flag_threshold: categories above this score are flagged (default 0.5).
+        Boolean flags follow each checker's own flagged decision. The
+        flag_threshold argument is kept for backward-compatible callers.
         """
         scores: Dict[str, float] = {}
+        flags: Dict[str, bool] = {}
         for result in self.results:
             if not result.success:
                 continue
             rt = result.risk_type.value
             scores[rt] = max(scores.get(rt, 0.0), result.score)
+            flags[rt] = flags.get(rt, False) or result.flagged
 
         self.category_scores = scores
-        self.categories = {rt: score >= flag_threshold for rt, score in scores.items()}
+        self.categories = {rt: flags.get(rt, False) for rt in scores}
         self.flagged = any(self.categories.values())
 
 

--- a/tools/security_audit/tool.py
+++ b/tools/security_audit/tool.py
@@ -16,7 +16,7 @@ from tools.base_tool import BaseTool, ToolContext
 from .config import AuditConfig, CheckerConfig, ExecutorConfig, LLMConfig
 from .executor import Executor
 from .loader import load_samples
-from .policy import validate_selected_checkers
+from .policy import resolve_default_checkers_for_resource_tier, validate_selected_checkers
 
 
 _DEFAULT_RISK_WEIGHTS = {
@@ -44,29 +44,53 @@ def _get_tool_defaults(context_config: dict) -> dict:
     return security_defaults if isinstance(security_defaults, dict) else {}
 
 
-def _resolve_checker_configs(kwargs: dict, tool_defaults: dict) -> list[CheckerConfig]:
+def _load_default_checker_configs(tool_defaults: dict) -> list[CheckerConfig]:
+    raw = tool_defaults.get("checkers")
+    if not isinstance(raw, list):
+        return []
+
+    configs: list[CheckerConfig] = []
+    for item in raw:
+        if isinstance(item, str):
+            configs.append(CheckerConfig(name=item, selection_source="config"))
+        elif isinstance(item, dict) and "name" in item:
+            configs.append(CheckerConfig(**{**item, "selection_source": "config"}))
+    return configs
+
+
+def _resolve_checker_configs(kwargs: dict, tool_defaults: dict, resource_tier: str) -> list[CheckerConfig]:
     """Resolve CheckerConfig list.
 
     Priority:
-      1. ``checkers`` list in tool_defaults (from default.yaml).
-      2. Built-in fallback: [PIIRule].
+      1. Explicit ``checker_names`` from tool call. These force-enable the
+         named checkers while inheriting same-name params from default.yaml.
+      2. Enabled ``checkers`` list in tool_defaults (from default.yaml).
+      3. Resource-tier default checkers.
     """
+    default_configs = _load_default_checker_configs(tool_defaults)
+    defaults_by_name = {config.name: config for config in default_configs}
+
     names = kwargs.get("checker_names")
-    if names:  # non-empty list → explicit override
-        return [CheckerConfig(name=n) for n in names]
-
-    raw = tool_defaults.get("checkers")
-    if raw and isinstance(raw, list):
+    if names:
         configs = []
-        for item in raw:
-            if isinstance(item, str):
-                configs.append(CheckerConfig(name=item))
-            elif isinstance(item, dict) and "name" in item:
-                configs.append(CheckerConfig(**item))
-        if configs:
-            return configs
+        for name in names:
+            default_config = defaults_by_name.get(name)
+            params = dict(default_config.params) if default_config else {}
+            configs.append(CheckerConfig(
+                name=name,
+                enabled=True,
+                params=params,
+                selection_source="explicit",
+            ))
+        return configs
 
-    return [CheckerConfig(name="PIIRule")]
+    if default_configs:
+        return default_configs
+
+    return [
+        CheckerConfig(name=name, selection_source="auto")
+        for name in resolve_default_checkers_for_resource_tier(resource_tier)
+    ]
 
 
 def _calc_security_score(risk_distribution: dict, risk_weights: dict) -> float:
@@ -137,30 +161,33 @@ class SecurityAuditTool(BaseTool):
         max_workers: int = kwargs.get("max_workers", 4)
 
         tool_defaults = _get_tool_defaults(context.config)
-        checker_configs = _resolve_checker_configs(kwargs, tool_defaults)
-        checker_names = [c.name for c in checker_configs if c.enabled]
         runtime_policy = build_runtime_policy(context.config)
-
+        checker_configs = _resolve_checker_configs(
+            kwargs,
+            tool_defaults,
+            runtime_policy.resource_tier,
+        )
         handle_preflight_issues(
             validate_selected_checkers(
                 checker_configs=checker_configs,
-                tool_defaults=tool_defaults,
                 runtime_policy=runtime_policy,
                 context_config=context.config,
             ),
             strict=runtime_policy.strict_preflight,
             logger=context.logger,
         )
+        checker_names = [c.name for c in checker_configs if c.enabled]
 
         if kwargs.get("checker_names"):
             context.log(f"SecurityAuditTool: using user-specified checkers: {checker_names}")
-        if tool_defaults.get("checkers"):
+        elif tool_defaults.get("checkers"):
             context.log(
                 f"SecurityAuditTool: using checkers from default.yaml: {checker_names}. "
             )
         else:
             context.log(
-                f"SecurityAuditTool: no checkers configured, using built-in default: {checker_names}"
+                f"SecurityAuditTool: no checkers configured, using "
+                f"{runtime_policy.resource_tier} resource-tier defaults: {checker_names}"
             )
 
         context.log(f"SecurityAuditTool: {len(data)} records, checkers={checker_names}")

--- a/tools/security_audit/tool.py
+++ b/tools/security_audit/tool.py
@@ -290,7 +290,7 @@ class SecurityAuditTool(BaseTool):
             context.log(f"SecurityAuditTool: using user-specified checkers: {checker_names}")
         elif plan.source == "default":
             context.log(
-                f"SecurityAuditTool: using checkers from default.yaml: {checker_names}. "
+                f"SecurityAuditTool: using configured default checkers: {checker_names}. "
             )
         elif plan.source == "recommend":
             context.log(
@@ -298,7 +298,8 @@ class SecurityAuditTool(BaseTool):
             )
         else:
             context.log(
-                f"SecurityAuditTool: using {plan.strategy} defaults: {checker_names}"
+                f"SecurityAuditTool: checker_selection_mode=default but tools/security_audit/default.yaml was not loaded; using resource-tier defaults: {checker_names}. To use your configured defaults, add or update tools/security_audit/default.yaml and set required_security_audit_tool: true in config.yaml.",
+                "warning",
             )
 
         for skipped in plan.skipped_checkers:

--- a/tools/security_audit/tool.py
+++ b/tools/security_audit/tool.py
@@ -16,9 +16,10 @@ from typing import Any
 from config import apply_runtime_environment, build_runtime_policy, handle_preflight_issues
 from tools.base_tool import BaseTool, ToolContext
 from .config import AuditConfig, CheckerConfig, ExecutorConfig, LLMConfig
+from .checker.registry import CheckerRegistry
 from .executor import Executor, _build_report_md
 from .loader import load_samples
-from .result import SampleReport, TaskReport
+from .result import CheckResult, SampleReport, TaskReport
 from .schema import DataSample
 from .policy import (
     ResolvedCheckerPlan,
@@ -70,6 +71,18 @@ _LOCAL_FILES_ONLY_CHECKERS = {
     "PromptInjectionClassifier",
     "BiasClassifier",
     "GraCeFulBackdoorDefender",
+}
+
+_CHECKER_REQUIRED_FIELDS = {
+    "DPOLabelFlipLLMJudge": {"chosen_response", "rejected_response"},
+    "FactualInconsistancyLLMJudge": {"context"},
+    "InstructionMismatchLLMJudge": {"response"},
+    "SycophancyLLMJudge": {"response"},
+    "GraCeFulBackdoorDefender": {"response"},
+}
+
+_CHECKER_REQUIRED_DATASET_TYPES = {
+    "DPOLabelFlipLLMJudge": {"dpo"},
 }
 
 
@@ -353,6 +366,7 @@ class SecurityAuditTool(BaseTool):
 
             stage_samples = self._select_stage_samples(
                 stage=stage,
+                stage_checker_configs=stage_checker_configs,
                 all_samples=samples,
                 samples_by_id=samples_by_id,
                 stage_reports_by_id=stage_reports_by_id,
@@ -487,56 +501,268 @@ class SecurityAuditTool(BaseTool):
         self,
         *,
         stage: dict[str, Any],
+        stage_checker_configs: list[CheckerConfig],
         all_samples: list[DataSample],
         samples_by_id: dict[str, DataSample],
         stage_reports_by_id: dict[str, dict[str, SampleReport]],
     ) -> list[DataSample]:
         routing = stage.get("routing") if isinstance(stage.get("routing"), dict) else {}
         mode = str(routing.get("mode") or "all_samples")
-        if mode in {"all_samples", "field_applicable"}:
+
+        if mode == "all_samples":
             return list(all_samples)
 
-        if mode == "uncertain":
-            return self._samples_flagged_by_source_stage(
+        if mode == "field_applicable":
+            return self._field_applicable_samples(
+                samples=list(all_samples),
+                checker_configs=stage_checker_configs,
                 routing=routing,
-                samples_by_id=samples_by_id,
-                stage_reports_by_id=stage_reports_by_id,
             )
 
         if mode == "sample":
-            return self._sample_routed_samples(list(all_samples), routing)
+            routed = self._field_applicable_samples(
+                samples=list(all_samples),
+                checker_configs=stage_checker_configs,
+                routing=routing,
+            )
+            return self._sample_routed_samples(routed, routing)
 
-        if mode == "high_risk_partition":
-            flagged = self._samples_flagged_by_source_stage(
+        if mode == "uncertain":
+            return self._samples_by_source_stage_rules(
                 routing=routing,
                 samples_by_id=samples_by_id,
                 stage_reports_by_id=stage_reports_by_id,
+                default_rules={"near_threshold", "low_confidence", "conflicting"},
             )
-            flagged_by_id = {sample.id for sample in flagged}
-            background = [sample for sample in all_samples if sample.id not in flagged_by_id]
-            return flagged + self._sample_routed_samples(background, routing)
 
-        return list(all_samples)
+        raise ValueError(f"Unsupported security_audit routing mode: {mode!r}")
 
-    def _samples_flagged_by_source_stage(
+    def _field_applicable_samples(
+        self,
+        *,
+        samples: list[DataSample],
+        checker_configs: list[CheckerConfig],
+        routing: dict[str, Any],
+    ) -> list[DataSample]:
+        if not samples:
+            return []
+
+        required_fields = set(self._routing_string_list(routing, "required_fields", "fields"))
+        dataset_types = set(self._routing_string_list(routing, "dataset_types", "dataset_type"))
+        applicable_mode = str(routing.get("applicable_mode") or "any_checker")
+
+        if dataset_types:
+            samples = [s for s in samples if str(s.dataset_type).lower() in dataset_types]
+
+        if required_fields:
+            samples = [s for s in samples if self._sample_has_required_fields(s, required_fields)]
+
+        if not checker_configs or applicable_mode == "none":
+            return samples
+
+        if applicable_mode == "all_checkers":
+            return [
+                sample for sample in samples
+                if all(self._checker_applicable_to_sample(config.name, sample) for config in checker_configs)
+            ]
+
+        return [
+            sample for sample in samples
+            if any(self._checker_applicable_to_sample(config.name, sample) for config in checker_configs)
+        ]
+
+    def _checker_applicable_to_sample(self, checker_name: str, sample: DataSample) -> bool:
+        dataset_types = _CHECKER_REQUIRED_DATASET_TYPES.get(checker_name)
+        if dataset_types and str(sample.dataset_type).lower() not in dataset_types:
+            return False
+
+        try:
+            checker_cls = CheckerRegistry.get(checker_name)
+        except KeyError:
+            return False
+
+        supported_formats = getattr(checker_cls, "supported_formats", None)
+        if supported_formats and sample.dataset_type not in supported_formats:
+            return False
+
+        required_fields = _CHECKER_REQUIRED_FIELDS.get(checker_name)
+        if required_fields:
+            return self._sample_has_required_fields(sample, required_fields)
+
+        return bool(sample.get_all_text_fields())
+
+    def _sample_has_required_fields(self, sample: DataSample, required_fields: set[str]) -> bool:
+        for field in required_fields:
+            normalized = str(field).strip().lower()
+            if normalized == "messages":
+                if not any(message.get_text_parts() for message in sample.messages):
+                    return False
+            elif normalized == "context":
+                if not self._has_text_value(sample.context):
+                    return False
+            elif normalized in {"response", "chosen_response", "rejected_response"}:
+                struct = getattr(sample, normalized, None)
+                if not struct or not self._has_text_value(getattr(struct, "content", None)):
+                    return False
+            else:
+                if not self._has_text_value(getattr(sample, normalized, None)):
+                    return False
+        return True
+
+    def _has_text_value(self, value: Any) -> bool:
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, list):
+            return any(self._has_text_value(item) for item in value)
+        return value is not None
+
+    def _samples_by_source_stage_rules(
         self,
         *,
         routing: dict[str, Any],
         samples_by_id: dict[str, DataSample],
         stage_reports_by_id: dict[str, dict[str, SampleReport]],
+        default_rules: set[str],
     ) -> list[DataSample]:
-        source_stage_id = routing.get("source_stage_id")
-        source_reports = stage_reports_by_id.get(str(source_stage_id or ""))
-        if source_reports is None and stage_reports_by_id:
-            latest_stage_id = next(reversed(stage_reports_by_id))
-            source_reports = stage_reports_by_id[latest_stage_id]
+        source_reports = self._source_stage_reports(routing, stage_reports_by_id)
         if not source_reports:
             return []
-        return [
-            samples_by_id[sample_id]
-            for sample_id, sample_report in source_reports.items()
-            if sample_report.flagged and sample_id in samples_by_id
-        ]
+
+        rules = set(self._routing_string_list(routing, "rules", "rule")) or default_rules
+        risk_types = set(self._routing_string_list(routing, "risk_types", "risk_type"))
+        checker_names = set(self._routing_string_list(routing, "checker_names", "checkers"))
+
+        selected: list[DataSample] = []
+        for sample_id, sample_report in source_reports.items():
+            if sample_id not in samples_by_id:
+                continue
+            results = [
+                result for result in sample_report.results
+                if self._result_matches_filters(result, risk_types, checker_names)
+            ]
+            if self._sample_report_matches_routing_rules(sample_report, results, rules, routing):
+                selected.append(samples_by_id[sample_id])
+        return selected
+
+    def _source_stage_reports(
+        self,
+        routing: dict[str, Any],
+        stage_reports_by_id: dict[str, dict[str, SampleReport]],
+    ) -> dict[str, SampleReport] | None:
+        source_stage_id = routing.get("source_stage_id")
+        if source_stage_id:
+            return stage_reports_by_id.get(str(source_stage_id))
+        if stage_reports_by_id:
+            latest_stage_id = next(reversed(stage_reports_by_id))
+            return stage_reports_by_id[latest_stage_id]
+        return None
+
+    def _result_matches_filters(
+        self,
+        result: CheckResult,
+        risk_types: set[str],
+        checker_names: set[str],
+    ) -> bool:
+        risk_value = getattr(result.risk_type, "value", str(result.risk_type))
+        if risk_types and str(risk_value).lower() not in risk_types:
+            return False
+        if checker_names and result.checker_name.lower() not in checker_names:
+            return False
+        return True
+
+    def _sample_report_matches_routing_rules(
+        self,
+        sample_report: SampleReport,
+        results: list[CheckResult],
+        rules: set[str],
+        routing: dict[str, Any],
+    ) -> bool:
+        if not results:
+            return False
+
+        if "flagged" in rules and any(result.flagged for result in results):
+            return True
+        if "unflagged" in rules and any(result.success for result in results) and not any(result.flagged for result in results):
+            return True
+        if "error" in rules and any(not result.success for result in results):
+            return True
+        if "content_filter" in rules and any(result.details.get("content_filter_triggered") for result in results):
+            return True
+        if "near_threshold" in rules and self._has_near_threshold_result(results, routing):
+            return True
+        if "low_confidence" in rules and self._has_low_confidence_result(results, routing):
+            return True
+        if "conflicting" in rules and self._has_conflicting_results(results):
+            return True
+        return False
+
+    def _has_near_threshold_result(
+        self,
+        results: list[CheckResult],
+        routing: dict[str, Any],
+    ) -> bool:
+        threshold = self._routing_float(routing, "threshold", default=0.5)
+        margin = self._routing_float(routing, "threshold_margin", "margin", default=0.1)
+        return any(
+            result.success and abs(float(result.score) - threshold) <= margin
+            for result in results
+        )
+
+    def _has_low_confidence_result(
+        self,
+        results: list[CheckResult],
+        routing: dict[str, Any],
+    ) -> bool:
+        max_confidence = self._routing_float(routing, "max_confidence", "confidence_threshold", default=0.7)
+        for result in results:
+            confidence = result.details.get("confidence")
+            if confidence is None:
+                confidence = result.details.get("confidence_score")
+            try:
+                if float(confidence) <= max_confidence:
+                    return True
+            except (TypeError, ValueError):
+                continue
+        return False
+
+    def _has_conflicting_results(self, results: list[CheckResult]) -> bool:
+        by_risk: dict[str, set[bool]] = {}
+        for result in results:
+            if not result.success:
+                continue
+            risk_value = getattr(result.risk_type, "value", str(result.risk_type))
+            by_risk.setdefault(str(risk_value), set()).add(bool(result.flagged))
+        return any(len(flags) > 1 for flags in by_risk.values())
+
+    def _routing_string_list(self, routing: dict[str, Any], *keys: str) -> list[str]:
+        for key in keys:
+            value = routing.get(key)
+            if value is None:
+                continue
+            if isinstance(value, str):
+                return [self._normalize_routing_token(item) for item in value.split(",") if item.strip()]
+            if isinstance(value, list):
+                return [self._normalize_routing_token(item) for item in value if str(item).strip()]
+            return [self._normalize_routing_token(value)]
+        return []
+
+    def _normalize_routing_token(self, value: Any) -> str:
+        return str(value).strip().lower().replace("-", "_")
+
+    def _routing_float(
+        self,
+        routing: dict[str, Any],
+        *keys: str,
+        default: float,
+    ) -> float:
+        for key in keys:
+            if key not in routing:
+                continue
+            try:
+                return float(routing[key])
+            except (TypeError, ValueError):
+                return default
+        return default
 
     def _sample_routed_samples(
         self,

--- a/tools/security_audit/tool.py
+++ b/tools/security_audit/tool.py
@@ -8,14 +8,18 @@ Pipeline usage:
     )
 """
 
+import json
 import os
+from datetime import datetime
 from typing import Any
 
 from config import apply_runtime_environment, build_runtime_policy, handle_preflight_issues
 from tools.base_tool import BaseTool, ToolContext
 from .config import AuditConfig, CheckerConfig, ExecutorConfig, LLMConfig
-from .executor import Executor
+from .executor import Executor, _build_report_md
 from .loader import load_samples
+from .result import SampleReport, TaskReport
+from .schema import DataSample
 from .policy import (
     ResolvedCheckerPlan,
     build_checker_capability_set,
@@ -60,6 +64,15 @@ def _get_config_value(section: Any, name: str, default: Any = None) -> Any:
     return getattr(section, name, default)
 
 
+_LOCAL_FILES_ONLY_CHECKERS = {
+    "HarmfulContentClassifier",
+    "JailbreakClassifier",
+    "PromptInjectionClassifier",
+    "BiasClassifier",
+    "GraCeFulBackdoorDefender",
+}
+
+
 def _apply_runtime_policy_to_checker_configs(
     checker_configs: list[CheckerConfig],
     runtime_policy: Any,
@@ -67,7 +80,8 @@ def _apply_runtime_policy_to_checker_configs(
     if runtime_policy.model_policy != "local_only":
         return
     for checker_config in checker_configs:
-        checker_config.params["local_files_only"] = True
+        if checker_config.name in _LOCAL_FILES_ONLY_CHECKERS:
+            checker_config.params["local_files_only"] = True
 
 
 def _calc_security_score(risk_distribution: dict, risk_weights: dict) -> float:
@@ -108,6 +122,14 @@ class SecurityAuditTool(BaseTool):
                     "items": {"type": "object"},
                     "description": "Dataset records to audit (list of dicts).",
                 },
+                "checker_selection_mode": {
+                    "type": "string",
+                    "enum": ["explicit", "recommend", "default"],
+                    "description": (
+                        "OPTIONAL. Checker selection mode. explicit requires checker_names; recommend uses "
+                        "audit_intent as the user's full audit intent; default uses the configured default checker set."
+                    ),
+                },
                 "checker_names": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -116,19 +138,12 @@ class SecurityAuditTool(BaseTool):
                         "the request is treated as checker_selection_mode='explicit'."
                     ),
                 },
-                "checker_selection_mode": {
-                    "type": "string",
-                    "enum": ["explicit", "recommend", "default"],
-                    "description": (
-                        "OPTIONAL. Checker selection intent. explicit requires checker_names; recommend may use "
-                        "checker_preferences; default uses the configured default checker set."
-                    ),
-                },
-                "checker_preferences": {
+                "audit_intent": {
                     "type": "string",
                     "description": (
-                        "OPTIONAL. Natural-language preferences for recommend mode, such as low cost, fast, "
-                        "high accuracy, or stronger coverage. Ignored in default mode."
+                        "OPTIONAL. Natural-language audit intent for recommend mode, including target risks, "
+                        "audit scope, checker focus, and constraints such as low cost, speed, high accuracy, "
+                        "or stronger coverage. Ignored in explicit or default mode."
                     ),
                 },
                 "max_workers": {
@@ -165,13 +180,24 @@ class SecurityAuditTool(BaseTool):
             runtime_policy=runtime_policy,
         )
 
-        # Step 3: Log the resolved single-stage plan.
+        # Step 3: Log the resolved plan.
         checker_configs = plan.checker_configs
         checker_names = [c.name for c in checker_configs if c.enabled]
         self._log_plan(context, plan, checker_names)
         context.log(f"SecurityAuditTool: {len(data)} records, checkers={checker_names}")
 
-        # TODO:Step 4: Execute the resolved plan.
+        # Step 4: Execute the resolved plan.
+        if plan.strategy == "llm":
+            return self._execute_multi_stage_plan(
+                context=context,
+                plan=plan,
+                data=data,
+                max_workers=max_workers,
+                tool_defaults=tool_defaults,
+                checker_names=checker_names,
+                runtime_policy=runtime_policy,
+            )
+
         return self._execute_single_stage_plan(
             context=context,
             plan=plan,
@@ -211,11 +237,20 @@ class SecurityAuditTool(BaseTool):
         )
 
         # TODO:Step 2.3: Resolve the execution plan within the capability set.
+        agent_cfg = context.config.get("agent")
+        tool_llm_cfg = context.config.get("tool_llm", {})
+        llm_model: str = (
+            _get_config_value(tool_llm_cfg, "model", "")
+            or _get_config_value(agent_cfg, "model", "")
+        )
         plan = resolve_checker_plan(
             request=request,
             capability_set=capability_set,
             tool_defaults=tool_defaults,
             resource_tier=runtime_policy.resource_tier,
+            llm=context.llm,
+            llm_model=llm_model,
+            logger=context.logger,
         )
 
         # TODO:Step 2.4: Inject runtime params and run final resolved-plan preflight.
@@ -258,6 +293,342 @@ class SecurityAuditTool(BaseTool):
                 f"SecurityAuditTool: skipped checker {skipped['name']} ({skipped['reason']}).",
                 "warning",
             )
+        context.log(f"SecurityAuditTool: resolved plan \n {plan.stages}")
+
+    def _execute_multi_stage_plan(
+        self,
+        *,
+        context: ToolContext,
+        plan: ResolvedCheckerPlan,
+        data: list[dict],
+        max_workers: int,
+        tool_defaults: dict,
+        checker_names: list[str],
+        runtime_policy: Any,
+    ) -> dict[str, Any]:
+        samples = load_samples(data)
+        samples_by_id = {sample.id: sample for sample in samples}
+        task_name = f"security_audit_{context.job_id}"
+        output_path = os.path.join("outputs", task_name)
+        stage_output_root = os.path.join(output_path, "stages")
+
+        agent_cfg = context.config.get("agent")
+        tool_llm_cfg = context.config.get("tool_llm", {})
+        llm_name: str = (
+            _get_config_value(tool_llm_cfg, "model", "")
+            or _get_config_value(agent_cfg, "model", "")
+        )
+        if llm_name:
+            context.log(f"Tool LLM model: {llm_name}", "info")
+
+        checker_configs_by_name = {
+            config.name: config
+            for config in plan.checker_configs
+            if config.enabled
+        }
+        merged_reports = {
+            sample.id: SampleReport(sample_id=sample.id)
+            for sample in samples
+        }
+        stage_reports_by_id: dict[str, dict[str, SampleReport]] = {}
+        stage_execution: list[dict[str, Any]] = []
+
+        for index, stage in enumerate(plan.stages, start=1):
+            stage_id = str(stage.get("id") or f"stage_{index}")
+            stage_checker_configs = self._checker_configs_for_stage(
+                stage=stage,
+                checker_configs_by_name=checker_configs_by_name,
+            )
+            if not stage_checker_configs:
+                context.log(f"SecurityAuditTool: stage {stage_id} skipped (no enabled checkers).", "warning")
+                stage_execution.append({
+                    "stage_id": stage_id,
+                    "checkers": [],
+                    "input_samples": 0,
+                    "flagged_samples": 0,
+                    "skipped": True,
+                    "reason": "no_enabled_checkers",
+                })
+                continue
+
+            stage_samples = self._select_stage_samples(
+                stage=stage,
+                all_samples=samples,
+                samples_by_id=samples_by_id,
+                stage_reports_by_id=stage_reports_by_id,
+            )
+            if not stage_samples:
+                context.log(f"SecurityAuditTool: stage {stage_id} skipped (no routed samples).", "warning")
+                stage_execution.append({
+                    "stage_id": stage_id,
+                    "checkers": [config.name for config in stage_checker_configs],
+                    "input_samples": 0,
+                    "flagged_samples": 0,
+                    "skipped": True,
+                    "reason": "no_routed_samples",
+                })
+                continue
+
+            context.log(
+                f"SecurityAuditTool: running stage {stage_id} on {len(stage_samples)} samples, "
+                f"checkers={[config.name for config in stage_checker_configs]}",
+                "info",
+            )
+            cfg = AuditConfig(
+                task_name=f"{task_name}_{stage_id}",
+                output_path=os.path.join(stage_output_root, stage_id),
+                checkers=[config.copy(deep=True) for config in stage_checker_configs],
+                executor=ExecutorConfig(max_workers=max_workers),
+                llm=LLMConfig(model=llm_name) if llm_name else None,
+                models=tool_defaults.get("models") or {},
+            )
+            engine = Executor(cfg, logger=context.logger, llm=context.llm, job_id=context.job_id, mode=context.mode)
+            engine.setup()
+            stage_report, stage_sample_reports = engine.run(stage_samples)
+            stage_reports_by_id[stage_id] = {
+                sample_report.sample_id: sample_report
+                for sample_report in stage_sample_reports
+            }
+            self._merge_stage_sample_reports(
+                merged_reports=merged_reports,
+                stage_sample_reports=stage_sample_reports,
+                stage_id=stage_id,
+            )
+            stage_execution.append({
+                "stage_id": stage_id,
+                "checkers": [config.name for config in stage_checker_configs],
+                "input_samples": len(stage_samples),
+                "flagged_samples": stage_report.flagged_samples,
+                "skipped": False,
+            })
+
+        sample_reports = list(merged_reports.values())
+        for sample_report in sample_reports:
+            sample_report.compute_category_scores()
+
+        task_report = TaskReport(
+            task_name=task_name,
+            output_path=output_path,
+            create_time=datetime.now().isoformat(),
+            total_samples=len(samples),
+        )
+        self._aggregate_sample_reports(task_report, sample_reports)
+        task_report.finish_time = datetime.now().isoformat()
+        self._write_multi_stage_artifacts(task_report, sample_reports)
+
+        flagged_rate = task_report.flagged_rate()
+        total_issues: int = task_report.flagged_samples
+        risk_weights: dict = tool_defaults.get("risk_weights")
+        if not risk_weights:
+            context.log("SecurityAuditTool: risk_weights not configured, using default weights.", "warning")
+            risk_weights = _DEFAULT_RISK_WEIGHTS
+        security_score = _calc_security_score(task_report.risk_distribution, risk_weights)
+
+        context.log(
+            f"Audit complete: {task_report.flagged_samples}/{task_report.total_samples} flagged "
+            f"({flagged_rate:.1%}), score={security_score}",
+            "info",
+        )
+
+        return {
+            "result": {
+                "security_score": security_score,
+                "total_issues": total_issues,
+                "flagged_samples": task_report.flagged_samples,
+                "safe_samples": task_report.safe_samples,
+                "total_samples": task_report.total_samples,
+                "flagged_rate": flagged_rate,
+                "risk_distribution": task_report.risk_distribution,
+                "checker_stats": task_report.checker_stats,
+            },
+            "metadata": {
+                "task_name": task_report.task_name,
+                "runtime_policy": {
+                    "network_mode": runtime_policy.network_mode,
+                    "resource_tier": runtime_policy.resource_tier,
+                },
+                "request": checker_request_metadata(plan.request) if plan.request else {},
+                "capability_set": capability_set_metadata(plan.capability_set) if plan.capability_set else {},
+                "resolved_plan": resolved_plan_metadata(plan),
+                "execution": {
+                    "max_workers": max_workers,
+                    "stages": stage_execution,
+                },
+                "checker_names": checker_names,
+                "checker_stats": task_report.checker_stats,
+                "create_time": task_report.create_time,
+                "finish_time": task_report.finish_time,
+            },
+            "artifacts": {
+                "report_md": os.path.join(output_path, "report.md"),
+                "sample_results": os.path.join(output_path, "sample_results.json"),
+            },
+        }
+
+    def _checker_configs_for_stage(
+        self,
+        *,
+        stage: dict[str, Any],
+        checker_configs_by_name: dict[str, CheckerConfig],
+    ) -> list[CheckerConfig]:
+        configs: list[CheckerConfig] = []
+        seen: set[str] = set()
+        for checker_name in stage.get("checkers", []):
+            if not isinstance(checker_name, str) or checker_name in seen:
+                continue
+            config = checker_configs_by_name.get(checker_name)
+            if not config:
+                continue
+            seen.add(checker_name)
+            configs.append(config)
+        return configs
+
+    def _select_stage_samples(
+        self,
+        *,
+        stage: dict[str, Any],
+        all_samples: list[DataSample],
+        samples_by_id: dict[str, DataSample],
+        stage_reports_by_id: dict[str, dict[str, SampleReport]],
+    ) -> list[DataSample]:
+        routing = stage.get("routing") if isinstance(stage.get("routing"), dict) else {}
+        mode = str(routing.get("mode") or "all_samples")
+        if mode in {"all_samples", "field_applicable"}:
+            return list(all_samples)
+
+        if mode == "uncertain":
+            return self._samples_flagged_by_source_stage(
+                routing=routing,
+                samples_by_id=samples_by_id,
+                stage_reports_by_id=stage_reports_by_id,
+            )
+
+        if mode == "sample":
+            return self._sample_routed_samples(list(all_samples), routing)
+
+        if mode == "high_risk_partition":
+            flagged = self._samples_flagged_by_source_stage(
+                routing=routing,
+                samples_by_id=samples_by_id,
+                stage_reports_by_id=stage_reports_by_id,
+            )
+            flagged_by_id = {sample.id for sample in flagged}
+            background = [sample for sample in all_samples if sample.id not in flagged_by_id]
+            return flagged + self._sample_routed_samples(background, routing)
+
+        return list(all_samples)
+
+    def _samples_flagged_by_source_stage(
+        self,
+        *,
+        routing: dict[str, Any],
+        samples_by_id: dict[str, DataSample],
+        stage_reports_by_id: dict[str, dict[str, SampleReport]],
+    ) -> list[DataSample]:
+        source_stage_id = routing.get("source_stage_id")
+        source_reports = stage_reports_by_id.get(str(source_stage_id or ""))
+        if source_reports is None and stage_reports_by_id:
+            latest_stage_id = next(reversed(stage_reports_by_id))
+            source_reports = stage_reports_by_id[latest_stage_id]
+        if not source_reports:
+            return []
+        return [
+            samples_by_id[sample_id]
+            for sample_id, sample_report in source_reports.items()
+            if sample_report.flagged and sample_id in samples_by_id
+        ]
+
+    def _sample_routed_samples(
+        self,
+        samples: list[DataSample],
+        routing: dict[str, Any],
+    ) -> list[DataSample]:
+        if not samples:
+            return []
+        raw_limit = routing.get("sample_size") or routing.get("max_samples") or routing.get("limit")
+        if raw_limit is not None:
+            try:
+                limit = max(0, int(raw_limit))
+            except (TypeError, ValueError):
+                limit = len(samples)
+            return samples[:limit] if limit else []
+        raw_rate = routing.get("sample_rate") or routing.get("rate")
+        if raw_rate is not None:
+            try:
+                rate = float(raw_rate)
+            except (TypeError, ValueError):
+                rate = 1.0
+            if rate <= 0:
+                return []
+            if rate >= 1:
+                return list(samples)
+            limit = max(1, int(len(samples) * rate))
+            return samples[:limit]
+        return list(samples)
+
+    def _merge_stage_sample_reports(
+        self,
+        *,
+        merged_reports: dict[str, SampleReport],
+        stage_sample_reports: list[SampleReport],
+        stage_id: str,
+    ) -> None:
+        for stage_sample_report in stage_sample_reports:
+            merged_report = merged_reports.setdefault(
+                stage_sample_report.sample_id,
+                SampleReport(sample_id=stage_sample_report.sample_id),
+            )
+            for result in stage_sample_report.results:
+                result.details = dict(result.details or {})
+                result.details.setdefault("stage_id", stage_id)
+                merged_report.results.append(result)
+
+    def _aggregate_sample_reports(
+        self,
+        task_report: TaskReport,
+        sample_reports: list[SampleReport],
+    ) -> None:
+        for sample_report in sample_reports:
+            if sample_report.flagged:
+                task_report.flagged_samples += 1
+            else:
+                task_report.safe_samples += 1
+
+            for risk_type, flagged in sample_report.categories.items():
+                task_report.risk_distribution.setdefault(risk_type, {"total": 0, "flagged": 0})
+                task_report.risk_distribution[risk_type]["total"] += 1
+                if flagged:
+                    task_report.risk_distribution[risk_type]["flagged"] += 1
+
+            for result in sample_report.results:
+                checker_name = result.checker_name
+                task_report.checker_stats.setdefault(
+                    checker_name,
+                    {"total": 0, "flagged": 0, "error": 0, "content_filter": 0},
+                )
+                if not result.success:
+                    task_report.checker_stats[checker_name]["error"] += 1
+                    if result.details.get("content_filter_triggered"):
+                        task_report.checker_stats[checker_name]["content_filter"] += 1
+                else:
+                    task_report.checker_stats[checker_name]["total"] += 1
+                    if result.flagged:
+                        task_report.checker_stats[checker_name]["flagged"] += 1
+
+    def _write_multi_stage_artifacts(
+        self,
+        task_report: TaskReport,
+        sample_reports: list[SampleReport],
+    ) -> None:
+        if not task_report.output_path:
+            return
+        os.makedirs(task_report.output_path, exist_ok=True)
+        json_path = os.path.join(task_report.output_path, "sample_results.json")
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump([report.model_dump() for report in sample_reports], f, ensure_ascii=False, indent=2)
+        md_path = os.path.join(task_report.output_path, "report.md")
+        with open(md_path, "w", encoding="utf-8") as f:
+            f.write(_build_report_md(task_report, sample_reports))
 
     def _execute_single_stage_plan(
         self,
@@ -271,8 +642,7 @@ class SecurityAuditTool(BaseTool):
         checker_names: list[str],
         runtime_policy: Any,
     ) -> dict[str, Any]:
-        # TODO: (resource_tier) Replace this single-stage executor with a
-        # strategy-aware multi-stage executor when funnel plans are implemented.
+        # Deterministic default and explicit selections run as one execution stage.
         samples = load_samples(data)
 
         agent_cfg = context.config.get("agent")
@@ -339,7 +709,6 @@ class SecurityAuditTool(BaseTool):
                     "max_workers": max_workers,
                 },
                 "checker_names": checker_names,
-                "checker_stats": task_report.checker_stats,
                 "create_time": task_report.create_time,
                 "finish_time": task_report.finish_time,
             },

--- a/tools/security_audit/tool.py
+++ b/tools/security_audit/tool.py
@@ -73,14 +73,6 @@ _LOCAL_FILES_ONLY_CHECKERS = {
     "GraCeFulBackdoorDefender",
 }
 
-_CHECKER_REQUIRED_FIELDS = {
-    "DPOLabelFlipLLMJudge": {"chosen_response", "rejected_response"},
-    "FactualInconsistancyLLMJudge": {"context"},
-    "InstructionMismatchLLMJudge": {"response"},
-    "SycophancyLLMJudge": {"response"},
-    "GraCeFulBackdoorDefender": {"response"},
-}
-
 _CHECKER_REQUIRED_DATASET_TYPES = {
     "DPOLabelFlipLLMJudge": {"dpo"},
 }
@@ -249,7 +241,7 @@ class SecurityAuditTool(BaseTool):
             context_config=context.config,
         )
 
-        # TODO:Step 2.3: Resolve the execution plan within the capability set.
+        # Step 2.3: Resolve the execution plan within the capability set.
         agent_cfg = context.config.get("agent")
         tool_llm_cfg = context.config.get("tool_llm", {})
         llm_model: str = (
@@ -586,11 +578,21 @@ class SecurityAuditTool(BaseTool):
         if supported_formats and sample.dataset_type not in supported_formats:
             return False
 
-        required_fields = _CHECKER_REQUIRED_FIELDS.get(checker_name)
+        required_fields = self._checker_required_fields(checker_name, checker_cls)
         if required_fields:
             return self._sample_has_required_fields(sample, required_fields)
 
         return bool(sample.get_all_text_fields())
+
+    def _checker_required_fields(self, checker_name: str, checker_cls: Any) -> set[str]:
+        metadata = getattr(checker_cls, "planner_metadata", None)
+        if isinstance(metadata, dict) and "required_fields" in metadata:
+            return {
+                self._normalize_routing_token(field)
+                for field in metadata.get("required_fields") or []
+                if str(field).strip()
+            }
+        return set()
 
     def _sample_has_required_fields(self, sample: DataSample, required_fields: set[str]) -> bool:
         for field in required_fields:

--- a/tools/security_audit/tool.py
+++ b/tools/security_audit/tool.py
@@ -20,7 +20,10 @@ from .policy import (
     ResolvedCheckerPlan,
     build_checker_capability_set,
     build_checker_request,
+    capability_set_metadata,
     resolve_checker_plan,
+    resolved_plan_metadata,
+    checker_request_metadata,
     validate_checker_request,
     validate_resolved_checker_plan,
 )
@@ -109,8 +112,23 @@ class SecurityAuditTool(BaseTool):
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
-                        "OPTIONAL. Omit this parameter unless the user explicitly names specific checkers to run. "
-                        "When omitted, the default checker list from configuration is used automatically."
+                        "OPTIONAL. Specific checker class names. If provided without checker_selection_mode, "
+                        "the request is treated as checker_selection_mode='explicit'."
+                    ),
+                },
+                "checker_selection_mode": {
+                    "type": "string",
+                    "enum": ["explicit", "recommend", "default"],
+                    "description": (
+                        "OPTIONAL. Checker selection intent. explicit requires checker_names; recommend may use "
+                        "checker_preferences; default uses the configured default checker set."
+                    ),
+                },
+                "checker_preferences": {
+                    "type": "string",
+                    "description": (
+                        "OPTIONAL. Natural-language preferences for recommend mode, such as low cost, fast, "
+                        "high accuracy, or stronger coverage. Ignored in default mode."
                     ),
                 },
                 "max_workers": {
@@ -150,7 +168,7 @@ class SecurityAuditTool(BaseTool):
         # Step 3: Log the resolved single-stage plan.
         checker_configs = plan.checker_configs
         checker_names = [c.name for c in checker_configs if c.enabled]
-        self._log_plan(context, plan, checker_names, bool(kwargs.get("checker_names")))
+        self._log_plan(context, plan, checker_names)
         context.log(f"SecurityAuditTool: {len(data)} records, checkers={checker_names}")
 
         # TODO:Step 4: Execute the resolved plan.
@@ -162,6 +180,7 @@ class SecurityAuditTool(BaseTool):
             tool_defaults=tool_defaults,
             checker_configs=checker_configs,
             checker_names=checker_names,
+            runtime_policy=runtime_policy,
         )
 
     def _build_execution_plan(
@@ -218,13 +237,16 @@ class SecurityAuditTool(BaseTool):
         context: ToolContext,
         plan: ResolvedCheckerPlan,
         checker_names: list[str],
-        explicit_checkers: bool,
     ) -> None:
-        if explicit_checkers:
+        if plan.source == "explicit":
             context.log(f"SecurityAuditTool: using user-specified checkers: {checker_names}")
-        elif plan.source == "config":
+        elif plan.source == "default":
             context.log(
                 f"SecurityAuditTool: using checkers from default.yaml: {checker_names}. "
+            )
+        elif plan.source == "recommend":
+            context.log(
+                f"SecurityAuditTool: using recommended checkers ({plan.strategy}): {checker_names}"
             )
         else:
             context.log(
@@ -247,6 +269,7 @@ class SecurityAuditTool(BaseTool):
         tool_defaults: dict,
         checker_configs: list[CheckerConfig],
         checker_names: list[str],
+        runtime_policy: Any,
     ) -> dict[str, Any]:
         # TODO: (resource_tier) Replace this single-stage executor with a
         # strategy-aware multi-stage executor when funnel plans are implemented.
@@ -305,22 +328,18 @@ class SecurityAuditTool(BaseTool):
             },
             "metadata": {
                 "task_name": task_report.task_name,
-                "checker_names": checker_names,
-                "resolved_plan": {
-                    "schema_version": "security_audit.resolved_plan.v1",
-                    "strategy": plan.strategy,
-                    "source": plan.source,
-                    "skipped_checkers": plan.skipped_checkers,
-                    "stages": [
-                        {
-                            "id": "stage_1",
-                            "name": "single_stage",
-                            "type": "single_stage",
-                            "checkers": checker_names,
-                            "input_scope": {"type": "all_samples"},
-                        }
-                    ],
+                "runtime_policy": {
+                    "network_mode": runtime_policy.network_mode,
+                    "resource_tier": runtime_policy.resource_tier,
                 },
+                "request": checker_request_metadata(plan.request) if plan.request else {},
+                "capability_set": capability_set_metadata(plan.capability_set) if plan.capability_set else {},
+                "resolved_plan": resolved_plan_metadata(plan),
+                "execution": {
+                    "max_workers": max_workers,
+                },
+                "checker_names": checker_names,
+                "checker_stats": task_report.checker_stats,
                 "create_time": task_report.create_time,
                 "finish_time": task_report.finish_time,
             },


### PR DESCRIPTION
## Changes

主要补充了 llm-based 漏斗策略：
1. 注释掉了`security_audit`工具的clarification代码；
2. 将checker选择逻辑下移到工具层，checker选择共三种模式：`explicit`/ `recommend` / `default`， recommend模式下基于llm解析用户意图并生成checker编排、样本路由的multi-stage plan，其他模式暂保持single-stage plan不变；
3. 相应地更新了docs

其他的修改：
1. 【和network preflight相关】实现了`ToxicityClassifier`的本地模型加载，需要配置的模型路径已写到default.yaml
<img width="841" height="133" alt="image" src="https://github.com/user-attachments/assets/4f2ea123-2a6c-47e9-8113-4cd4dc5e5270" />
2. 修复了一些bug
